### PR TITLE
Update three dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
 	},
 
 	"dependencies": {
-		"three": "0.82.x"
+		"three": ">= 0.82.x"
 	},
 
 	"devDependencies": {


### PR DESCRIPTION
This change makes inclusion of postprocessing as a module in other projects only include three, once, rather than multiple versions as it does presently.