### PR TITLE
Version 6.0.0

### DIFF
--- a/demo/assets/index.debug.html
+++ b/demo/assets/index.debug.html
@@ -6,7 +6,7 @@
 		<title>Demo - Post Processing</title>
 		<link rel="shortcut icon" href="favicon.ico" type="image/x-icon">
 		<link rel="stylesheet" href="styles.css">
-		<script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/101/three.min.js"></script>
+		<script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/102/three.min.js"></script>
 		<script src="index.js"></script>
 	</head>
 	<body>

--- a/demo/assets/index.html
+++ b/demo/assets/index.html
@@ -6,7 +6,7 @@
 		<title>Demo - Post Processing</title>
 		<link rel="shortcut icon" href="favicon.ico" type="image/x-icon">
 		<link rel="stylesheet" href="styles.css">
-		<script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/101/three.min.js"></script>
+		<script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/102/three.min.js"></script>
 		<script src="index.min.js"></script>
 	</head>
 	<body>

--- a/demo/src/demos/GodRaysDemo.js
+++ b/demo/src/demos/GodRaysDemo.js
@@ -222,12 +222,12 @@ export class GodRaysDemo extends PostProcessingDemo {
 		const smaaEffect = new SMAAEffect(assets.get("smaa-search"), assets.get("smaa-area"));
 		smaaEffect.setEdgeDetectionThreshold(0.065);
 
-		const godRaysEffect = new GodRaysEffect(scene, camera, sun, {
+		const godRaysEffect = new GodRaysEffect(camera, sun, {
 			resolutionScale: 0.75,
 			kernelSize: KernelSize.SMALL,
 			density: 0.96,
-			decay: 0.90,
-			weight: 0.4,
+			decay: 0.93,
+			weight: 0.3,
 			exposure: 0.55,
 			samples: 60,
 			clampMax: 1.0

--- a/demo/src/demos/SMAADemo.js
+++ b/demo/src/demos/SMAADemo.js
@@ -11,6 +11,7 @@ import {
 	PerspectiveCamera,
 	RepeatWrapping,
 	TextureLoader,
+	Vector2,
 	WebGLRenderer
 } from "three";
 
@@ -223,7 +224,7 @@ export class SMAADemo extends PostProcessingDemo {
 			return renderer;
 
 		})(
-			renderer.getSize(),
+			renderer.getSize(new Vector2()),
 			renderer.getClearColor(),
 			renderer.getPixelRatio()
 		);
@@ -421,7 +422,7 @@ export class SMAADemo extends PostProcessingDemo {
 
 		function swapRenderers(browser) {
 
-			const size = composer.renderer.getSize();
+			const size = composer.renderer.getSize(new Vector2());
 
 			if(browser && composer.renderer !== renderer2) {
 

--- a/demo/src/demos/SSAODemo.js
+++ b/demo/src/demos/SSAODemo.js
@@ -10,6 +10,7 @@ import {
 	PerspectiveCamera,
 	PlaneBufferGeometry,
 	PointLight,
+	Vector2,
 	WebGLRenderer
 } from "three";
 
@@ -145,7 +146,7 @@ export class SSAODemo extends PostProcessingDemo {
 
 		const renderer = ((renderer) => {
 
-			const size = renderer.getSize();
+			const size = renderer.getSize(new Vector2());
 			const pixelRatio = renderer.getPixelRatio();
 
 			renderer = new WebGLRenderer({

--- a/demo/src/index.js
+++ b/demo/src/index.js
@@ -1,5 +1,5 @@
 import { DemoManager } from "three-demo";
-import { WebGLRenderer } from "three";
+import { Vector2, WebGLRenderer } from "three";
 import { EffectComposer } from "../../src";
 
 import { BloomDemo } from "./demos/BloomDemo.js";
@@ -75,7 +75,7 @@ function onChange(event) {
 	const demo = event.demo;
 
 	// Make sure that the main renderer is being used and update it just in case.
-	const size = composer.renderer.getSize();
+	const size = composer.renderer.getSize(new Vector2());
 	renderer.setSize(size.width, size.height);
 	composer.replaceRenderer(renderer);
 	composer.reset();

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
 	},
 
 	"peerDependencies": {
-		"three": ">= 0.87.0 < 0.102.0"
+		"three": ">= 0.87.0 < 0.103.0"
 	},
 
 	"devDependencies": {
@@ -91,7 +91,7 @@
 		"rollup-plugin-node-resolve": "4.x.x",
 		"rollup-plugin-string": "2.x.x",
 		"synthetic-event": "0.x.x",
-		"three": "0.101.x",
+		"three": "0.102.x",
 		"three-demo": "3.x.x",
 		"three-gltf-loader": "1.101.x"
 	}

--- a/public/demo/index.debug.html
+++ b/public/demo/index.debug.html
@@ -6,7 +6,7 @@
 		<title>Demo - Post Processing</title>
 		<link rel="shortcut icon" href="favicon.ico" type="image/x-icon">
 		<link rel="stylesheet" href="styles.css">
-		<script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/101/three.min.js"></script>
+		<script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/102/three.min.js"></script>
 		<script src="index.js"></script>
 	</head>
 	<body>

--- a/public/demo/index.html
+++ b/public/demo/index.html
@@ -6,7 +6,7 @@
 		<title>Demo - Post Processing</title>
 		<link rel="shortcut icon" href="favicon.ico" type="image/x-icon">
 		<link rel="stylesheet" href="styles.css">
-		<script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/101/three.min.js"></script>
+		<script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/102/three.min.js"></script>
 		<script src="index.min.js"></script>
 	</head>
 	<body>

--- a/src/core/EffectComposer.js
+++ b/src/core/EffectComposer.js
@@ -324,10 +324,10 @@ export class EffectComposer {
 	/**
 	 * Renders all enabled passes in the order in which they were added.
 	 *
-	 * @param {Number} delta - The time between the last frame and the current one in seconds.
+	 * @param {Number} deltaTime - The time between the last frame and the current one in seconds.
 	 */
 
-	render(delta) {
+	render(deltaTime) {
 
 		const renderer = this.renderer;
 		const copyPass = this.copyPass;
@@ -342,7 +342,7 @@ export class EffectComposer {
 
 			if(pass.enabled) {
 
-				pass.render(renderer, inputBuffer, outputBuffer, delta, stencilTest);
+				pass.render(renderer, inputBuffer, outputBuffer, deltaTime, stencilTest);
 
 				if(pass.needsSwap) {
 
@@ -355,7 +355,7 @@ export class EffectComposer {
 
 						// Preserve the unaffected pixels.
 						state.buffers.stencil.setFunc(context.NOTEQUAL, 1, 0xffffffff);
-						copyPass.render(renderer, inputBuffer, outputBuffer, delta, stencilTest);
+						copyPass.render(renderer, inputBuffer, outputBuffer, deltaTime, stencilTest);
 						state.buffers.stencil.setFunc(context.EQUAL, 1, 0xffffffff);
 
 					}

--- a/src/core/EffectComposer.js
+++ b/src/core/EffectComposer.js
@@ -30,7 +30,7 @@ export class EffectComposer {
 	/**
 	 * Constructs a new effect composer.
 	 *
-	 * @param {WebGLRenderer} [renderer] - The renderer that should be used.
+	 * @param {WebGLRenderer} renderer - The renderer that should be used.
 	 * @param {Object} [options] - The options.
 	 * @param {Boolean} [options.depthBuffer=true] - Whether the main render targets should have a depth buffer.
 	 * @param {Boolean} [options.stencilBuffer=false] - Whether the main render targets should have a stencil buffer.
@@ -50,6 +50,7 @@ export class EffectComposer {
 		 * {@link EffectComposer#replaceRenderer}.
 		 *
 		 * @type {WebGLRenderer}
+		 * @private
 		 */
 
 		this.renderer = renderer;
@@ -100,6 +101,18 @@ export class EffectComposer {
 		 */
 
 		this.passes = [];
+
+	}
+
+	/**
+	 * Returns the WebGL renderer.
+	 *
+	 * @return {WebGLRenderer} The renderer.
+	 */
+
+	getRenderer(renderer) {
+
+		return this.renderer;
 
 	}
 

--- a/src/core/EffectComposer.js
+++ b/src/core/EffectComposer.js
@@ -5,6 +5,7 @@ import {
 	RGBAFormat,
 	RGBFormat,
 	UnsignedInt248Type,
+	Vector2,
 	WebGLRenderTarget
 } from "three";
 
@@ -118,27 +119,25 @@ export class EffectComposer {
 
 		const oldRenderer = this.renderer;
 
-		let parent, oldSize, newSize;
-
 		if(oldRenderer !== null && oldRenderer !== renderer) {
+
+			const oldSize = oldRenderer.getSize(new Vector2());
+			const newSize = renderer.getSize(new Vector2());
+			const parent = oldRenderer.domElement.parentNode;
 
 			this.renderer = renderer;
 			this.renderer.autoClear = false;
 
-			parent = oldRenderer.domElement.parentNode;
-			oldSize = oldRenderer.getSize();
-			newSize = renderer.getSize();
+			if(!oldSize.equals(newSize)) {
+
+				this.setSize();
+
+			}
 
 			if(parent !== null) {
 
 				parent.removeChild(oldRenderer.domElement);
 				parent.appendChild(renderer.domElement);
-
-			}
-
-			if(oldSize.width !== newSize.width || oldSize.height !== newSize.height) {
-
-				this.setSize();
 
 			}
 
@@ -231,7 +230,7 @@ export class EffectComposer {
 
 	createBuffer(depthBuffer, stencilBuffer) {
 
-		const drawingBufferSize = this.renderer.getDrawingBufferSize();
+		const drawingBufferSize = this.renderer.getDrawingBufferSize(new Vector2());
 		const alpha = this.renderer.context.getContextAttributes().alpha;
 
 		const renderTarget = new WebGLRenderTarget(drawingBufferSize.width, drawingBufferSize.height, {
@@ -259,7 +258,7 @@ export class EffectComposer {
 	addPass(pass, index) {
 
 		const renderer = this.renderer;
-		const drawingBufferSize = renderer.getDrawingBufferSize();
+		const drawingBufferSize = renderer.getDrawingBufferSize(new Vector2());
 
 		pass.setSize(drawingBufferSize.width, drawingBufferSize.height);
 		pass.initialize(renderer, renderer.context.getContextAttributes().alpha);
@@ -378,11 +377,9 @@ export class EffectComposer {
 
 		const renderer = this.renderer;
 
-		let size, drawingBufferSize;
-
 		if(width === undefined || height === undefined) {
 
-			size = renderer.getSize();
+			const size = renderer.getSize(new Vector2());
 			width = size.width; height = size.height;
 
 		}
@@ -391,7 +388,7 @@ export class EffectComposer {
 		renderer.setSize(width, height);
 
 		// The drawing buffer size takes the device pixel ratio into account.
-		drawingBufferSize = renderer.getDrawingBufferSize();
+		const drawingBufferSize = renderer.getDrawingBufferSize(new Vector2());
 
 		this.inputBuffer.setSize(drawingBufferSize.width, drawingBufferSize.height);
 		this.outputBuffer.setSize(drawingBufferSize.width, drawingBufferSize.height);

--- a/src/core/EffectComposer.js
+++ b/src/core/EffectComposer.js
@@ -19,8 +19,7 @@ import { CopyMaterial } from "../materials";
  * unnecessary clear operations.
  *
  * It is common practice to use a {@link RenderPass} as the first pass to
- * automatically clear the screen and render the scene to a texture for further
- * processing.
+ * automatically clear the buffers and render a scene for further processing.
  *
  * @implements {Resizable}
  * @implements {Disposable}

--- a/src/core/EffectComposer.js
+++ b/src/core/EffectComposer.js
@@ -36,12 +36,7 @@ export class EffectComposer {
 	 * @param {Boolean} [options.stencilBuffer=false] - Whether the main render targets should have a stencil buffer.
 	 */
 
-	constructor(renderer = null, options = {}) {
-
-		const settings = Object.assign({
-			depthBuffer: true,
-			stencilBuffer: false
-		}, options);
+	constructor(renderer = null, { depthBuffer = true, stencilBuffer = false } = {}) {
 
 		/**
 		 * The renderer.
@@ -79,7 +74,7 @@ export class EffectComposer {
 		if(this.renderer !== null) {
 
 			this.renderer.autoClear = false;
-			this.inputBuffer = this.createBuffer(settings.depthBuffer, settings.stencilBuffer);
+			this.inputBuffer = this.createBuffer(depthBuffer, stencilBuffer);
 			this.outputBuffer = this.inputBuffer.clone();
 
 		}

--- a/src/effects/BloomEffect.js
+++ b/src/effects/BloomEffect.js
@@ -32,18 +32,11 @@ export class BloomEffect extends Effect {
 	 * @param {KernelSize} [options.kernelSize=KernelSize.LARGE] - The blur kernel size.
 	 */
 
-	constructor(options = {}) {
-
-		const settings = Object.assign({
-			blendFunction: BlendFunction.SCREEN,
-			resolutionScale: 0.5,
-			kernelSize: KernelSize.LARGE,
-			distinction: 1.0
-		}, options);
+	constructor({ blendFunction = BlendFunction.SCREEN, distinction = 1.0, resolutionScale = 0.5, kernelSize = KernelSize.LARGE } = {}) {
 
 		super("BloomEffect", fragment, {
 
-			blendFunction: settings.blendFunction,
+			blendFunction,
 
 			uniforms: new Map([
 				["texture", new Uniform(null)]
@@ -71,6 +64,15 @@ export class BloomEffect extends Effect {
 		this.uniforms.get("texture").value = this.renderTarget.texture;
 
 		/**
+		 * A blur pass.
+		 *
+		 * @type {BlurPass}
+		 * @private
+		 */
+
+		this.blurPass = new BlurPass({ resolutionScale, kernelSize });
+
+		/**
 		 * The original resolution.
 		 *
 		 * @type {Vector2}
@@ -78,15 +80,6 @@ export class BloomEffect extends Effect {
 		 */
 
 		this.resolution = new Vector2();
-
-		/**
-		 * A blur pass.
-		 *
-		 * @type {BlurPass}
-		 * @private
-		 */
-
-		this.blurPass = new BlurPass(settings);
 
 		/**
 		 * A luminance shader pass.
@@ -97,8 +90,7 @@ export class BloomEffect extends Effect {
 
 		this.luminancePass = new ShaderPass(new LuminanceMaterial(true));
 
-		this.distinction = settings.distinction;
-		this.kernelSize = settings.kernelSize;
+		this.distinction = distinction;
 
 	}
 

--- a/src/effects/BloomEffect.js
+++ b/src/effects/BloomEffect.js
@@ -27,9 +27,9 @@ export class BloomEffect extends Effect {
 	 *
 	 * @param {Object} [options] - The options.
 	 * @param {BlendFunction} [options.blendFunction=BlendFunction.SCREEN] - The blend function of this effect.
-	 * @param {Number} [options.resolutionScale=0.5] - The render texture resolution scale, relative to the screen render size.
-	 * @param {Number} [options.kernelSize=KernelSize.LARGE] - The blur kernel size.
 	 * @param {Number} [options.distinction=1.0] - The luminance distinction factor. Raise this value to bring out the brighter elements in the scene.
+	 * @param {Number} [options.resolutionScale=0.5] - The render texture resolution scale, relative to the main frame buffer size.
+	 * @param {KernelSize} [options.kernelSize=KernelSize.LARGE] - The blur kernel size.
 	 */
 
 	constructor(options = {}) {

--- a/src/effects/BloomEffect.js
+++ b/src/effects/BloomEffect.js
@@ -215,10 +215,10 @@ export class BloomEffect extends Effect {
 	 *
 	 * @param {WebGLRenderer} renderer - The renderer.
 	 * @param {WebGLRenderTarget} inputBuffer - A frame buffer that contains the result of the previous pass.
-	 * @param {Number} [delta] - The time between the last frame and the current one in seconds.
+	 * @param {Number} [deltaTime] - The time between the last frame and the current one in seconds.
 	 */
 
-	update(renderer, inputBuffer, delta) {
+	update(renderer, inputBuffer, deltaTime) {
 
 		const renderTarget = this.renderTarget;
 

--- a/src/effects/BokehEffect.js
+++ b/src/effects/BokehEffect.js
@@ -24,26 +24,18 @@ export class BokehEffect extends Effect {
 	 * @param {Number} [options.maxBlur=1.0] - The maximum blur strength.
 	 */
 
-	constructor(options = {}) {
-
-		const settings = Object.assign({
-			blendFunction: BlendFunction.NORMAL,
-			focus: 0.5,
-			dof: 0.02,
-			aperture: 0.015,
-			maxBlur: 1.0
-		}, options);
+	constructor({ blendFunction = BlendFunction.NORMAL, focus = 0.5, dof = 0.02, aperture = 0.015, maxBlur = 1.0 } = {}) {
 
 		super("BokehEffect", fragment, {
 
+			blendFunction,
 			attributes: EffectAttribute.CONVOLUTION | EffectAttribute.DEPTH,
-			blendFunction: settings.blendFunction,
 
 			uniforms: new Map([
-				["focus", new Uniform(settings.focus)],
-				["dof", new Uniform(settings.dof)],
-				["aperture", new Uniform(settings.aperture)],
-				["maxBlur", new Uniform(settings.maxBlur)]
+				["focus", new Uniform(focus)],
+				["dof", new Uniform(dof)],
+				["aperture", new Uniform(aperture)],
+				["maxBlur", new Uniform(maxBlur)]
 			])
 
 		});

--- a/src/effects/BokehEffect.js
+++ b/src/effects/BokehEffect.js
@@ -5,7 +5,7 @@ import { Effect, EffectAttribute } from "./Effect.js";
 import fragment from "./glsl/bokeh/shader.frag";
 
 /**
- * A depth of field (bokeh) shader effect.
+ * A depth of field (bokeh) effect.
  *
  * Original shader code by Martins Upitis:
  *  http://artmartinsh.blogspot.com/2010/02/glsl-lens-blur-filter-with-bokeh.html

--- a/src/effects/BrightnessContrastEffect.js
+++ b/src/effects/BrightnessContrastEffect.js
@@ -21,21 +21,15 @@ export class BrightnessContrastEffect extends Effect {
 	 * @param {Number} [options.contrast=0.0] - The contrast factor, ranging from -1 to 1, where 0 means no change.
 	 */
 
-	constructor(options = {}) {
-
-		const settings = Object.assign({
-			blendFunction: BlendFunction.NORMAL,
-			brightness: 0.0,
-			contrast: 0.0
-		}, options);
+	constructor({ blendFunction = BlendFunction.NORMAL, brightness = 0.0, contrast = 0.0 } = {}) {
 
 		super("BrightnessContrastEffect", fragment, {
 
-			blendFunction: settings.blendFunction,
+			blendFunction,
 
 			uniforms: new Map([
-				["brightness", new Uniform(settings.brightness)],
-				["contrast", new Uniform(settings.contrast)]
+				["brightness", new Uniform(brightness)],
+				["contrast", new Uniform(contrast)]
 			])
 
 		});

--- a/src/effects/ChromaticAberrationEffect.js
+++ b/src/effects/ChromaticAberrationEffect.js
@@ -19,20 +19,15 @@ export class ChromaticAberrationEffect extends Effect {
 	 * @param {Vector2} [options.offset] - The color offset.
 	 */
 
-	constructor(options = {}) {
-
-		const settings = Object.assign({
-			blendFunction: BlendFunction.NORMAL,
-			offset: new Vector2(0.001, 0.0005)
-		}, options);
+	constructor({ blendFunction = BlendFunction.NORMAL, offset = new Vector2(0.001, 0.0005) } = {}) {
 
 		super("ChromaticAberrationEffect", fragment, {
 
+			blendFunction,
 			attributes: EffectAttribute.CONVOLUTION,
-			blendFunction: settings.blendFunction,
 
 			uniforms: new Map([
-				["offset", new Uniform(settings.offset)]
+				["offset", new Uniform(offset)]
 			]),
 
 			vertexShader: vertex

--- a/src/effects/DepthEffect.js
+++ b/src/effects/DepthEffect.js
@@ -19,21 +19,16 @@ export class DepthEffect extends Effect {
 	 * @param {Boolean} [options.inverted=false] - Whether the depth values should be inverted.
 	 */
 
-	constructor(options = {}) {
-
-		const settings = Object.assign({
-			blendFunction: BlendFunction.NORMAL,
-			inverted: false
-		}, options);
+	constructor({ blendFunction = BlendFunction.NORMAL, inverted = false } = {}) {
 
 		super("DepthEffect", fragment, {
 
-			attributes: EffectAttribute.DEPTH,
-			blendFunction: settings.blendFunction
+			blendFunction,
+			attributes: EffectAttribute.DEPTH
 
 		});
 
-		this.inverted = settings.inverted;
+		this.inverted = inverted;
 
 	}
 

--- a/src/effects/DotScreenEffect.js
+++ b/src/effects/DotScreenEffect.js
@@ -19,26 +19,20 @@ export class DotScreenEffect extends Effect {
 	 * @param {Number} [options.scale=1.0] - The scale of the dot pattern.
 	 */
 
-	constructor(options = {}) {
-
-		const settings = Object.assign({
-			blendFunction: BlendFunction.NORMAL,
-			angle: Math.PI * 0.5,
-			scale: 1.0
-		}, options);
+	constructor({ blendFunction = BlendFunction.NORMAL, angle = Math.PI * 0.5, scale = 1.0 } = {}) {
 
 		super("DotScreenEffect", fragment, {
 
-			blendFunction: settings.blendFunction,
+			blendFunction,
 
 			uniforms: new Map([
 				["angle", new Uniform(new Vector2())],
-				["scale", new Uniform(settings.scale)]
+				["scale", new Uniform(scale)]
 			])
 
 		});
 
-		this.setAngle(settings.angle);
+		this.setAngle(angle);
 
 	}
 

--- a/src/effects/Effect.js
+++ b/src/effects/Effect.js
@@ -27,16 +27,14 @@ export class Effect {
 	 * @param {String} [options.vertexShader=null] - The vertex shader. Most effects don't need one.
 	 */
 
-	constructor(name, fragmentShader, options = {}) {
-
-		const settings = Object.assign({
-			attributes: EffectAttribute.NONE,
-			blendFunction: BlendFunction.SCREEN,
-			defines: new Map(),
-			uniforms: new Map(),
-			extensions: null,
-			vertexShader: null
-		}, options);
+	constructor(name, fragmentShader, {
+		attributes = EffectAttribute.NONE,
+		blendFunction = BlendFunction.SCREEN,
+		defines = new Map(),
+		uniforms = new Map(),
+		extensions = null,
+		vertexShader = null
+	} = {}) {
 
 		/**
 		 * The name of this effect.
@@ -55,7 +53,7 @@ export class Effect {
 		 * @type {EffectAttribute}
 		 */
 
-		this.attributes = settings.attributes;
+		this.attributes = attributes;
 
 		/**
 		 * The fragment shader.
@@ -71,7 +69,7 @@ export class Effect {
 		 * @type {String}
 		 */
 
-		this.vertexShader = settings.vertexShader;
+		this.vertexShader = vertexShader;
 
 		/**
 		 * Preprocessor macro definitions.
@@ -81,7 +79,7 @@ export class Effect {
 		 * @type {Map<String, String>}
 		 */
 
-		this.defines = settings.defines;
+		this.defines = defines;
 
 		/**
 		 * Shader uniforms.
@@ -92,7 +90,7 @@ export class Effect {
 		 * @type {Map<String, Uniform>}
 		 */
 
-		this.uniforms = settings.uniforms;
+		this.uniforms = uniforms;
 
 		/**
 		 * WebGL extensions that are required by this effect.
@@ -103,7 +101,7 @@ export class Effect {
 		 * @type {Set<WebGLExtension>}
 		 */
 
-		this.extensions = settings.extensions;
+		this.extensions = extensions;
 
 		/**
 		 * The blend mode of this effect.
@@ -118,7 +116,7 @@ export class Effect {
 		 * @type {BlendMode}
 		 */
 
-		this.blendMode = new BlendMode(settings.blendFunction);
+		this.blendMode = new BlendMode(blendFunction);
 
 	}
 

--- a/src/effects/Effect.js
+++ b/src/effects/Effect.js
@@ -145,10 +145,10 @@ export class Effect {
 	 *
 	 * @param {WebGLRenderer} renderer - The renderer.
 	 * @param {WebGLRenderTarget} inputBuffer - A frame buffer that contains the result of the previous pass.
-	 * @param {Number} [delta] - The time between the last frame and the current one in seconds.
+	 * @param {Number} [deltaTime] - The time between the last frame and the current one in seconds.
 	 */
 
-	update(renderer, inputBuffer, delta) {}
+	update(renderer, inputBuffer, deltaTime) {}
 
 	/**
 	 * Updates the size of this effect.

--- a/src/effects/GammaCorrectionEffect.js
+++ b/src/effects/GammaCorrectionEffect.js
@@ -18,19 +18,14 @@ export class GammaCorrectionEffect extends Effect {
 	 * @param {Number} [options.gamma=2.0] - The gamma factor.
 	 */
 
-	constructor(options = {}) {
-
-		const settings = Object.assign({
-			blendFunction: BlendFunction.NORMAL,
-			gamma: 2.0
-		}, options);
+	constructor({ blendFunction = BlendFunction.NORMAL, gamma = 2.0 } = {}) {
 
 		super("GammaCorrectionEffect", fragment, {
 
-			blendFunction: settings.blendFunction,
+			blendFunction,
 
 			uniforms: new Map([
-				["gamma", new Uniform(settings.gamma)]
+				["gamma", new Uniform(gamma)]
 			])
 
 		});

--- a/src/effects/GlitchEffect.js
+++ b/src/effects/GlitchEffect.js
@@ -284,10 +284,10 @@ export class GlitchEffect extends Effect {
 	 *
 	 * @param {WebGLRenderer} renderer - The renderer.
 	 * @param {WebGLRenderTarget} inputBuffer - A frame buffer that contains the result of the previous pass.
-	 * @param {Number} [delta] - The time between the last frame and the current one in seconds.
+	 * @param {Number} [deltaTime] - The time between the last frame and the current one in seconds.
 	 */
 
-	update(renderer, inputBuffer, delta) {
+	update(renderer, inputBuffer, deltaTime) {
 
 		const mode = this.mode;
 		const breakPoint = this.breakPoint;
@@ -303,7 +303,7 @@ export class GlitchEffect extends Effect {
 
 			if(mode === GlitchMode.SPORADIC) {
 
-				time += delta;
+				time += deltaTime;
 				trigger = (time > breakPoint.x);
 
 				if(time >= (breakPoint.x + breakPoint.y)) {

--- a/src/effects/GlitchEffect.js
+++ b/src/effects/GlitchEffect.js
@@ -64,27 +64,25 @@ export class GlitchEffect extends Effect {
 	 * @param {Number} [options.ratio=0.85] - The threshold for strong glitches.
 	 */
 
-	constructor(options = {}) {
-
-		const settings = Object.assign({
-			blendFunction: BlendFunction.NORMAL,
-			chromaticAberrationOffset: null,
-			delay: new Vector2(1.5, 3.5),
-			duration: new Vector2(0.6, 1.0),
-			strength: new Vector2(0.3, 1.0),
-			columns: 0.05,
-			ratio: 0.85,
-			perturbationMap: null,
-			dtSize: 64
-		}, options);
+	constructor({
+		blendFunction = BlendFunction.NORMAL,
+		chromaticAberrationOffset = null,
+		delay = new Vector2(1.5, 3.5),
+		duration = new Vector2(0.6, 1.0),
+		strength = new Vector2(0.3, 1.0),
+		columns = 0.05,
+		ratio = 0.85,
+		perturbationMap = null,
+		dtSize = 64
+	} = {}) {
 
 		super("GlitchEffect", fragment, {
 
-			blendFunction: settings.blendFunction,
+			blendFunction,
 
 			uniforms: new Map([
 				["perturbationMap", new Uniform(null)],
-				["columns", new Uniform(settings.columns)],
+				["columns", new Uniform(columns)],
 				["active", new Uniform(false)],
 				["random", new Uniform(0.02)],
 				["seed", new Uniform(new Vector2())],
@@ -102,9 +100,9 @@ export class GlitchEffect extends Effect {
 
 		this.perturbationMap = null;
 
-		this.setPerturbationMap((settings.perturbationMap === null) ?
-			this.generatePerturbationMap(settings.dtSize) :
-			settings.perturbationMap);
+		this.setPerturbationMap((perturbationMap === null) ?
+			this.generatePerturbationMap(dtSize) :
+			perturbationMap);
 
 		this.perturbationMap.generateMipmaps = false;
 
@@ -114,7 +112,7 @@ export class GlitchEffect extends Effect {
 		 * @type {Vector2}
 		 */
 
-		this.delay = settings.delay;
+		this.delay = delay;
 
 		/**
 		 * The minimum and maximum duration of a glitch in seconds.
@@ -122,7 +120,7 @@ export class GlitchEffect extends Effect {
 		 * @type {Vector2}
 		 */
 
-		this.duration = settings.duration;
+		this.duration = duration;
 
 		/**
 		 * A random glitch break point.
@@ -177,7 +175,7 @@ export class GlitchEffect extends Effect {
 		 * @type {Vector2}
 		 */
 
-		this.strength = settings.strength;
+		this.strength = strength;
 
 		/**
 		 * The threshold for strong glitches, ranging from 0 to 1 where 0 means no
@@ -187,7 +185,7 @@ export class GlitchEffect extends Effect {
 		 * @type {Number}
 		 */
 
-		this.ratio = settings.ratio;
+		this.ratio = ratio;
 
 		/**
 		 * The chromatic aberration offset.
@@ -195,7 +193,7 @@ export class GlitchEffect extends Effect {
 		 * @type {Vector2}
 		 */
 
-		this.chromaticAberrationOffset = settings.chromaticAberrationOffset;
+		this.chromaticAberrationOffset = chromaticAberrationOffset;
 
 	}
 

--- a/src/effects/GodRaysEffect.js
+++ b/src/effects/GodRaysEffect.js
@@ -172,9 +172,8 @@ export class GodRaysEffect extends Effect {
 		 * @private
 		 */
 
-		this.renderPassLight = new RenderPass(this.lightScene, camera, {
-			clearColor: new Color(0x000000)
-		});
+		this.renderPassLight = new RenderPass(this.lightScene, camera);
+		this.renderPassLight.getClearPass().overrideClearColor = new Color(0x000000);
 
 		/**
 		 * A pass that renders the masked scene over the light source.

--- a/src/effects/GodRaysEffect.js
+++ b/src/effects/GodRaysEffect.js
@@ -46,19 +46,17 @@ export class GodRaysEffect extends Effect {
 	 * @param {Number} [options.blur=true] - Whether the god rays should be blurred to reduce artifacts.
 	 */
 
-	constructor(scene, camera, lightSource, options = {}) {
-
-		const settings = Object.assign({
-			blendFunction: BlendFunction.SCREEN,
-			resolutionScale: 0.5,
-			samples: 60.0,
-			blur: true,
-			kernelSize: KernelSize.SMALL
-		}, options);
+	constructor(scene, camera, lightSource, {
+		blendFunction = BlendFunction.SCREEN,
+		samples = 60.0,
+		resolutionScale = 0.5,
+		kernelSize = KernelSize.SMALL,
+		blur = true
+	} = {}) {
 
 		super("GodRaysEffect", fragment, {
 
-			blendFunction: settings.blendFunction,
+			blendFunction,
 
 			uniforms: new Map([
 				["texture", new Uniform(null)]
@@ -199,7 +197,7 @@ export class GodRaysEffect extends Effect {
 		 * @private
 		 */
 
-		this.blurPass = new BlurPass(settings);
+		this.blurPass = new BlurPass({ resolutionScale, kernelSize });
 
 		/**
 		 * A god rays pass.
@@ -208,11 +206,10 @@ export class GodRaysEffect extends Effect {
 		 * @private
 		 */
 
-		this.godRaysPass = new ShaderPass(new GodRaysMaterial(this.screenPosition, settings));
+		this.godRaysPass = new ShaderPass(new GodRaysMaterial(this.screenPosition));
 
-		this.blur = settings.blur;
-		this.kernelSize = settings.kernelSize;
-		this.samples = settings.samples;
+		this.blur = blur;
+		this.samples = samples;
 
 	}
 

--- a/src/effects/GodRaysEffect.js
+++ b/src/effects/GodRaysEffect.js
@@ -1,7 +1,7 @@
 import {
 	Color,
+	DepthTexture,
 	LinearFilter,
-	MeshBasicMaterial,
 	RGBFormat,
 	Scene,
 	Uniform,
@@ -10,10 +10,10 @@ import {
 	WebGLRenderTarget
 } from "three";
 
-import { KernelSize, GodRaysMaterial } from "../materials";
-import { BlurPass, RenderPass, ShaderPass } from "../passes";
+import { DepthMaskMaterial, KernelSize, GodRaysMaterial } from "../materials";
+import { BlurPass, ClearPass, RenderPass, ShaderPass } from "../passes";
 import { BlendFunction } from "./blending/BlendFunction.js";
-import { Effect } from "./Effect.js";
+import { Effect, EffectAttribute } from "./Effect.js";
 
 import fragment from "./glsl/texture/shader.frag";
 
@@ -35,20 +35,29 @@ export class GodRaysEffect extends Effect {
 	/**
 	 * Constructs a new god rays effect.
 	 *
-	 * @param {Scene} scene - The main scene.
 	 * @param {Camera} camera - The main camera.
-	 * @param {Object3D} lightSource - The main light source.
+	 * @param {Mesh|Points} lightSource - The light source. Must not write depth and has to be flagged as transparent.
 	 * @param {Object} [options] - The options.
 	 * @param {BlendFunction} [options.blendFunction=BlendFunction.SCREEN] - The blend function of this effect.
 	 * @param {Number} [options.samples=60.0] - The number of samples per pixel.
+	 * @param {Number} [options.density=0.96] - The density of the light rays.
+	 * @param {Number} [options.decay=0.9] - An illumination decay factor.
+	 * @param {Number} [options.weight=0.4] - A light ray weight factor.
+	 * @param {Number} [options.exposure=0.6] - A constant attenuation coefficient.
+	 * @param {Number} [options.clampMax=1.0] - An upper bound for the saturation of the overall effect.
 	 * @param {Number} [options.resolutionScale=0.5] - The render texture resolution scale, relative to the screen render size.
 	 * @param {KernelSize} [options.kernelSize=KernelSize.SMALL] - The blur kernel size. Has no effect if blur is disabled.
 	 * @param {Number} [options.blur=true] - Whether the god rays should be blurred to reduce artifacts.
 	 */
 
-	constructor(scene, camera, lightSource, {
+	constructor(camera, lightSource, {
 		blendFunction = BlendFunction.SCREEN,
 		samples = 60.0,
+		density = 0.96,
+		decay = 0.9,
+		weight = 0.4,
+		exposure = 0.6,
+		clampMax = 1.0,
 		resolutionScale = 0.5,
 		kernelSize = KernelSize.SMALL,
 		blur = true
@@ -57,21 +66,13 @@ export class GodRaysEffect extends Effect {
 		super("GodRaysEffect", fragment, {
 
 			blendFunction,
+			attributes: EffectAttribute.DEPTH,
 
 			uniforms: new Map([
 				["texture", new Uniform(null)]
 			])
 
 		});
-
-		/**
-		 * The main scene.
-		 *
-		 * @type {Scene}
-		 * @private
-		 */
-
-		this.scene = scene;
 
 		/**
 		 * The main camera.
@@ -85,10 +86,13 @@ export class GodRaysEffect extends Effect {
 		/**
 		 * The light source.
 		 *
-		 * @type {Object3D}
+		 * @type {Mesh|Points}
+		 * @private
 		 */
 
 		this.lightSource = lightSource;
+		this.lightSource.material.depthWrite = false;
+		this.lightSource.material.transparent = true;
 
 		/**
 		 * A scene that only contains the light source.
@@ -133,10 +137,8 @@ export class GodRaysEffect extends Effect {
 
 		this.renderTargetX.texture.name = "GodRays.TargetX";
 
-		this.uniforms.get("texture").value = this.renderTargetX.texture;
-
 		/**
-		 * A second render target.
+		 * A render target.
 		 *
 		 * @type {WebGLRenderTarget}
 		 * @private
@@ -144,17 +146,19 @@ export class GodRaysEffect extends Effect {
 
 		this.renderTargetY = this.renderTargetX.clone();
 		this.renderTargetY.texture.name = "GodRays.TargetY";
+		this.uniforms.get("texture").value = this.renderTargetY.texture;
 
 		/**
-		 * A render target for the masked light scene.
+		 * A render target for the light scene.
 		 *
 		 * @type {WebGLRenderTarget}
 		 * @private
 		 */
 
-		this.renderTargetMask = this.renderTargetX.clone();
-		this.renderTargetMask.texture.name = "GodRays.Mask";
-		this.renderTargetMask.texture.depthBuffer = true;
+		this.renderTargetLight = this.renderTargetX.clone();
+		this.renderTargetLight.texture.name = "GodRays.Light";
+		this.renderTargetLight.depthBuffer = true;
+		this.renderTargetLight.depthTexture = new DepthTexture();
 
 		/**
 		 * A pass that only renders the light source.
@@ -167,19 +171,13 @@ export class GodRaysEffect extends Effect {
 		this.renderPassLight.getClearPass().overrideClearColor = new Color(0x000000);
 
 		/**
-		 * A pass that renders the masked scene over the light source.
+		 * A clear pass.
 		 *
-		 * @type {RenderPass}
+		 * @type {ClearPass}
 		 * @private
 		 */
 
-		this.renderPassMask = new RenderPass(scene, camera, new MeshBasicMaterial({
-			color: 0x000000,
-			morphTargets: true,
-			skinning: true
-		}));
-
-		this.renderPassMask.clear = false;
+		this.clearPass = new ClearPass(true, false, false);
 
 		/**
 		 * A blur pass.
@@ -191,16 +189,36 @@ export class GodRaysEffect extends Effect {
 		this.blurPass = new BlurPass({ resolutionScale, kernelSize });
 
 		/**
-		 * A god rays pass.
+		 * A depth mask pass.
 		 *
 		 * @type {ShaderPass}
 		 * @private
 		 */
 
-		this.godRaysPass = new ShaderPass(new GodRaysMaterial(this.screenPosition));
+		this.depthMaskPass = new ShaderPass(new DepthMaskMaterial());
 
-		this.blur = blur;
+		/**
+		 * A god rays blur pass.
+		 *
+		 * @type {ShaderPass}
+		 * @private
+		 */
+
+		this.godRaysPass = new ShaderPass((() => {
+
+			const material = new GodRaysMaterial(this.screenPosition);
+			material.uniforms.density.value = density;
+			material.uniforms.decay.value = decay;
+			material.uniforms.weight.value = weight;
+			material.uniforms.exposure.value = exposure;
+			material.uniforms.clampMax.value = clampMax;
+
+			return material;
+
+		})());
+
 		this.samples = samples;
+		this.blur = blur;
 
 	}
 
@@ -215,7 +233,7 @@ export class GodRaysEffect extends Effect {
 
 	get texture() {
 
-		return this.renderTargetX.texture;
+		return this.renderTargetY.texture;
 
 	}
 
@@ -293,6 +311,8 @@ export class GodRaysEffect extends Effect {
 	}
 
 	/**
+	 * Sets the blur kernel size.
+	 *
 	 * @type {KernelSize}
 	 */
 
@@ -340,8 +360,7 @@ export class GodRaysEffect extends Effect {
 	}
 
 	/**
-	 * This value must be carefully chosen. A higher value improves quality but
-	 * also increases the GPU load.
+	 * A higher sample count improves quality at the cost of performance.
 	 *
 	 * @type {Number}
 	 */
@@ -349,6 +368,22 @@ export class GodRaysEffect extends Effect {
 	set samples(value) {
 
 		this.godRaysMaterial.samples = value;
+
+	}
+
+	/**
+	 * Sets the depth texture.
+	 *
+	 * @param {Texture} depthTexture - A depth texture.
+	 * @param {Number} [depthPacking=0] - The depth packing.
+	 */
+
+	setDepthTexture(depthTexture, depthPacking = 0) {
+
+		const material = this.depthMaskPass.getFullscreenMaterial();
+
+		material.uniforms.depthBuffer0.value = depthTexture;
+		material.uniforms.depthBuffer1.value = this.renderTargetLight.depthTexture;
 
 	}
 
@@ -362,12 +397,10 @@ export class GodRaysEffect extends Effect {
 
 	update(renderer, inputBuffer, deltaTime) {
 
-		const scene = this.scene;
 		const lightSource = this.lightSource;
-		const renderTargetMask = this.renderTargetMask;
-		const renderTargetY = this.renderTargetY;
-
-		let background, parent;
+		const parent = lightSource.parent;
+		const renderTargetX = this.renderTargetX;
+		const renderTargetLight = this.renderTargetLight;
 
 		// Compute the screen light position and translate it to [0.0, 1.0].
 		v.copy(lightSource.position).project(this.camera);
@@ -376,15 +409,13 @@ export class GodRaysEffect extends Effect {
 			Math.max(0.0, Math.min(1.0, (v.y + 1.0) * 0.5)),
 		);
 
-		parent = lightSource.parent;
-		background = scene.background;
-		scene.background = null;
+		// Render the light source and mask it based on depth.
+		lightSource.material.depthWrite = true;
 		this.lightScene.add(lightSource);
-
-		/* First, render the light source. Then render the scene into the same
-		buffer using a mask override material with depth test enabled. */
-		this.renderPassLight.render(renderer, renderTargetMask);
-		this.renderPassMask.render(renderer, renderTargetMask);
+		this.renderPassLight.render(renderer, renderTargetLight);
+		this.clearPass.render(renderer, renderTargetX);
+		this.depthMaskPass.render(renderer, renderTargetLight, renderTargetX);
+		lightSource.material.depthWrite = false;
 
 		if(parent !== null) {
 
@@ -392,19 +423,15 @@ export class GodRaysEffect extends Effect {
 
 		}
 
-		scene.background = background;
-		inputBuffer = renderTargetMask;
-
 		if(this.blur) {
 
 			// Blur the masked scene to reduce artifacts.
-			this.blurPass.render(renderer, inputBuffer, renderTargetY);
-			inputBuffer = renderTargetY;
+			this.blurPass.render(renderer, renderTargetX, renderTargetX);
 
 		}
 
 		// Blur the masked scene along radial lines towards the light source.
-		this.godRaysPass.render(renderer, inputBuffer, this.renderTargetX);
+		this.godRaysPass.render(renderer, renderTargetX, this.renderTargetY);
 
 	}
 
@@ -418,17 +445,18 @@ export class GodRaysEffect extends Effect {
 	setSize(width, height) {
 
 		this.resolution.set(width, height);
+
 		this.renderPassLight.setSize(width, height);
-		this.renderPassMask.setSize(width, height);
 		this.blurPass.setSize(width, height);
+		this.depthMaskPass.setSize(width, height);
 		this.godRaysPass.setSize(width, height);
 
 		width = this.blurPass.width;
 		height = this.blurPass.height;
 
-		this.renderTargetMask.setSize(width, height);
 		this.renderTargetX.setSize(width, height);
 		this.renderTargetY.setSize(width, height);
+		this.renderTargetLight.setSize(width, height);
 
 	}
 
@@ -442,15 +470,15 @@ export class GodRaysEffect extends Effect {
 	initialize(renderer, alpha) {
 
 		this.renderPassLight.initialize(renderer, alpha);
-		this.renderPassMask.initialize(renderer, alpha);
 		this.blurPass.initialize(renderer, alpha);
+		this.depthMaskPass.initialize(renderer, alpha);
 		this.godRaysPass.initialize(renderer, alpha);
 
 		if(!alpha) {
 
-			this.renderTargetMask.texture.format = RGBFormat;
 			this.renderTargetX.texture.format = RGBFormat;
 			this.renderTargetY.texture.format = RGBFormat;
+			this.renderTargetLight.texture.format = RGBFormat;
 
 		}
 

--- a/src/effects/GodRaysEffect.js
+++ b/src/effects/GodRaysEffect.js
@@ -370,10 +370,10 @@ export class GodRaysEffect extends Effect {
 	 *
 	 * @param {WebGLRenderer} renderer - The renderer.
 	 * @param {WebGLRenderTarget} inputBuffer - A frame buffer that contains the result of the previous pass.
-	 * @param {Number} [delta] - The time between the last frame and the current one in seconds.
+	 * @param {Number} [deltaTime] - The time between the last frame and the current one in seconds.
 	 */
 
-	update(renderer, inputBuffer, delta) {
+	update(renderer, inputBuffer, deltaTime) {
 
 		const scene = this.scene;
 		const lightSource = this.lightSource;

--- a/src/effects/GodRaysEffect.js
+++ b/src/effects/GodRaysEffect.js
@@ -38,12 +38,12 @@ export class GodRaysEffect extends Effect {
 	 * @param {Scene} scene - The main scene.
 	 * @param {Camera} camera - The main camera.
 	 * @param {Object3D} lightSource - The main light source.
-	 * @param {Object} [options] - The options. See {@link GodRaysMaterial} for additional options.
+	 * @param {Object} [options] - The options.
 	 * @param {BlendFunction} [options.blendFunction=BlendFunction.SCREEN] - The blend function of this effect.
-	 * @param {Number} [options.resolutionScale=0.5] - The render texture resolution scale, relative to the screen render size.
 	 * @param {Number} [options.samples=60.0] - The number of samples per pixel.
+	 * @param {Number} [options.resolutionScale=0.5] - The render texture resolution scale, relative to the screen render size.
+	 * @param {KernelSize} [options.kernelSize=KernelSize.SMALL] - The blur kernel size. Has no effect if blur is disabled.
 	 * @param {Number} [options.blur=true] - Whether the god rays should be blurred to reduce artifacts.
-	 * @param {Number} [options.kernelSize=KernelSize.SMALL] - The blur kernel size. Has no effect if blur is disabled.
 	 */
 
 	constructor(scene, camera, lightSource, options = {}) {

--- a/src/effects/GodRaysEffect.js
+++ b/src/effects/GodRaysEffect.js
@@ -132,7 +132,6 @@ export class GodRaysEffect extends Effect {
 		});
 
 		this.renderTargetX.texture.name = "GodRays.TargetX";
-		this.renderTargetX.texture.generateMipmaps = false;
 
 		this.uniforms.get("texture").value = this.renderTargetX.texture;
 
@@ -144,7 +143,6 @@ export class GodRaysEffect extends Effect {
 		 */
 
 		this.renderTargetY = this.renderTargetX.clone();
-
 		this.renderTargetY.texture.name = "GodRays.TargetY";
 
 		/**
@@ -154,14 +152,9 @@ export class GodRaysEffect extends Effect {
 		 * @private
 		 */
 
-		this.renderTargetMask = new WebGLRenderTarget(1, 1, {
-			minFilter: LinearFilter,
-			magFilter: LinearFilter,
-			stencilBuffer: false
-		});
-
+		this.renderTargetMask = this.renderTargetX.clone();
 		this.renderTargetMask.texture.name = "GodRays.Mask";
-		this.renderTargetMask.texture.generateMipmaps = false;
+		this.renderTargetMask.texture.depthBuffer = true;
 
 		/**
 		 * A pass that only renders the light source.
@@ -180,13 +173,11 @@ export class GodRaysEffect extends Effect {
 		 * @private
 		 */
 
-		this.renderPassMask = new RenderPass(scene, camera, {
-			overrideMaterial: new MeshBasicMaterial({
-				color: 0x000000,
-				morphTargets: true,
-				skinning: true
-			})
-		});
+		this.renderPassMask = new RenderPass(scene, camera, new MeshBasicMaterial({
+			color: 0x000000,
+			morphTargets: true,
+			skinning: true
+		}));
 
 		this.renderPassMask.clear = false;
 

--- a/src/effects/GridEffect.js
+++ b/src/effects/GridEffect.js
@@ -19,21 +19,15 @@ export class GridEffect extends Effect {
 	 * @param {Number} [options.lineWidth=0.0] - The line width of the grid pattern.
 	 */
 
-	constructor(options = {}) {
-
-		const settings = Object.assign({
-			blendFunction: BlendFunction.OVERLAY,
-			scale: 1.0,
-			lineWidth: 0.0
-		}, options);
+	constructor({ blendFunction = BlendFunction.OVERLAY, scale = 1.0, lineWidth = 0.0 } = {}) {
 
 		super("GridEffect", fragment, {
 
-			blendFunction: settings.blendFunction,
+			blendFunction,
 
 			uniforms: new Map([
 				["scale", new Uniform(new Vector2())],
-				["lineWidth", new Uniform(settings.lineWidth)]
+				["lineWidth", new Uniform(lineWidth)]
 			])
 
 		});
@@ -54,7 +48,7 @@ export class GridEffect extends Effect {
 		 * @private
 		 */
 
-		this.scale = Math.max(settings.scale, 1e-6);
+		this.scale = Math.max(scale, 1e-6);
 
 		/**
 		 * The grid line width.
@@ -63,7 +57,7 @@ export class GridEffect extends Effect {
 		 * @private
 		 */
 
-		this.lineWidth = Math.max(settings.lineWidth, 0.0);
+		this.lineWidth = Math.max(lineWidth, 0.0);
 
 	}
 

--- a/src/effects/HueSaturationEffect.js
+++ b/src/effects/HueSaturationEffect.js
@@ -21,26 +21,20 @@ export class HueSaturationEffect extends Effect {
 	 * @param {Number} [options.saturation=0.0] - The saturation factor, ranging from -1 to 1, where 0 means no change.
 	 */
 
-	constructor(options = {}) {
-
-		const settings = Object.assign({
-			blendFunction: BlendFunction.NORMAL,
-			hue: 0.0,
-			saturation: 0.0
-		}, options);
+	constructor({ blendFunction = BlendFunction.NORMAL, hue = 0.0, saturation = 0.0 } = {}) {
 
 		super("HueSaturationEffect", fragment, {
 
-			blendFunction: settings.blendFunction,
+			blendFunction,
 
 			uniforms: new Map([
 				["hue", new Uniform(new Vector3())],
-				["saturation", new Uniform(settings.saturation)]
+				["saturation", new Uniform(saturation)]
 			])
 
 		});
 
-		this.setHue(settings.hue);
+		this.setHue(hue);
 
 	}
 

--- a/src/effects/NoiseEffect.js
+++ b/src/effects/NoiseEffect.js
@@ -17,16 +17,11 @@ export class NoiseEffect extends Effect {
 	 * @param {Boolean} [options.premultiply=false] - Whether the noise should be multiplied with the input color.
 	 */
 
-	constructor(options = {}) {
+	constructor({ blendFunction = BlendFunction.SCREEN, premultiply = false } = {}) {
 
-		const settings = Object.assign({
-			blendFunction: BlendFunction.SCREEN,
-			premultiply: false
-		}, options);
+		super("NoiseEffect", fragment, { blendFunction });
 
-		super("NoiseEffect", fragment, { blendFunction: settings.blendFunction });
-
-		this.premultiply = settings.premultiply;
+		this.premultiply = premultiply;
 
 	}
 

--- a/src/effects/OutlineEffect.js
+++ b/src/effects/OutlineEffect.js
@@ -30,19 +30,21 @@ export class OutlineEffect extends Effect {
 	/**
 	 * Constructs a new outline effect.
 	 *
-	 * If you want dark outlines, remember to adjust the blend function.
+	 * If you want dark outlines, remember to use an appropriate blend function.
 	 *
 	 * @param {Scene} scene - The main scene.
 	 * @param {Camera} camera - The main camera.
-	 * @param {Object} [options] - The options. See {@link BlurPass} and {@link OutlineEdgesMaterial} for additional parameters.
+	 * @param {Object} [options] - The options.
 	 * @param {BlendFunction} [options.blendFunction=BlendFunction.SCREEN] - The blend function.  Set this to `BlendFunction.ALPHA` for dark outlines.
 	 * @param {Number} [options.patternTexture=null] - A pattern texture.
 	 * @param {Number} [options.edgeStrength=1.0] - The edge strength.
 	 * @param {Number} [options.pulseSpeed=0.0] - The pulse speed. A value of zero disables the pulse effect.
 	 * @param {Number} [options.visibleEdgeColor=0xffffff] - The color of visible edges.
 	 * @param {Number} [options.hiddenEdgeColor=0x22090a] - The color of hidden edges.
+	 * @param {Number} [options.resolutionScale=0.5] - The render texture resolution scale, relative to the main frame buffer size.
+	 * @param {KernelSize} [options.kernelSize=KernelSize.VERY_SMALL] - The blur kernel size.
 	 * @param {Boolean} [options.blur=false] - Whether the outline should be blurred.
-	 * @param {Boolean} [options.xRay=true] - Whether hidden parts of selected objects should be visible.
+	 * @param {Boolean} [options.xRay=true] - Whether occluded parts of selected objects should be visible.
 	 */
 
 	constructor(scene, camera, options = {}) {
@@ -301,6 +303,8 @@ export class OutlineEffect extends Effect {
 	}
 
 	/**
+	 * Sets the kernel size.
+	 *
 	 * @type {KernelSize}
 	 */
 

--- a/src/effects/OutlineEffect.js
+++ b/src/effects/OutlineEffect.js
@@ -159,10 +159,9 @@ export class OutlineEffect extends Effect {
 		 * @private
 		 */
 
-		this.clearPass = new ClearPass({
-			clearColor: new Color(0x000000),
-			clearAlpha: 1.0
-		});
+		this.clearPass = new ClearPass();
+		this.clearPass.overrideClearColor = new Color(0x000000);
+		this.clearPass.overrideClearAlpha = 1.0;
 
 		/**
 		 * A depth pass.
@@ -180,11 +179,11 @@ export class OutlineEffect extends Effect {
 		 * @private
 		 */
 
-		this.maskPass = new RenderPass(this.mainScene, this.mainCamera, {
-			overrideMaterial: new DepthComparisonMaterial(this.depthPass.renderTarget.texture, this.mainCamera),
-			clearColor: new Color(0xffffff),
-			clearAlpha: 1.0
-		});
+		this.maskPass = new RenderPass(scene, camera, new DepthComparisonMaterial(this.depthPass.renderTarget.texture, camera));
+
+		const clearPass = this.maskPass.getClearPass();
+		clearPass.overrideClearColor = new Color(0xffffff);
+		clearPass.overrideClearAlpha = 1.0;
 
 		/**
 		 * A blur pass.

--- a/src/effects/OutlineEffect.js
+++ b/src/effects/OutlineEffect.js
@@ -8,12 +8,7 @@ import {
 	WebGLRenderTarget
 } from "three";
 
-import {
-	DepthComparisonMaterial,
-	OutlineEdgesMaterial,
-	KernelSize
-} from "../materials";
-
+import { DepthComparisonMaterial, OutlineEdgesMaterial, KernelSize } from "../materials";
 import { BlurPass, ClearPass, DepthPass, RenderPass, ShaderPass } from "../passes";
 import { BlendFunction } from "./blending/BlendFunction.js";
 import { Effect } from "./Effect.js";
@@ -47,36 +42,36 @@ export class OutlineEffect extends Effect {
 	 * @param {Boolean} [options.xRay=true] - Whether occluded parts of selected objects should be visible.
 	 */
 
-	constructor(scene, camera, options = {}) {
-
-		const settings = Object.assign({
-			blendFunction: BlendFunction.SCREEN,
-			patternTexture: null,
-			edgeStrength: 1.0,
-			pulseSpeed: 0.0,
-			visibleEdgeColor: 0xffffff,
-			hiddenEdgeColor: 0x22090a,
-			blur: false,
-			xRay: true
-		}, options);
+	constructor(scene, camera, {
+		blendFunction = BlendFunction.SCREEN,
+		patternTexture = null,
+		edgeStrength = 1.0,
+		pulseSpeed = 0.0,
+		visibleEdgeColor = 0xffffff,
+		hiddenEdgeColor = 0x22090a,
+		resolutionScale = 0.5,
+		kernelSize = KernelSize.VERY_SMALL,
+		blur = false,
+		xRay = true
+	} = {}) {
 
 		super("OutlineEffect", fragment, {
 
-			blendFunction: settings.blendFunction,
+			blendFunction,
 
 			uniforms: new Map([
 				["maskTexture", new Uniform(null)],
 				["edgeTexture", new Uniform(null)],
-				["edgeStrength", new Uniform(settings.edgeStrength)],
-				["visibleEdgeColor", new Uniform(new Color(settings.visibleEdgeColor))],
-				["hiddenEdgeColor", new Uniform(new Color(settings.hiddenEdgeColor))],
+				["edgeStrength", new Uniform(edgeStrength)],
+				["visibleEdgeColor", new Uniform(new Color(visibleEdgeColor))],
+				["hiddenEdgeColor", new Uniform(new Color(hiddenEdgeColor))],
 				["pulse", new Uniform(1.0)]
 			])
 
 		});
 
-		this.setPatternTexture(settings.patternTexture);
-		this.xRay = settings.xRay;
+		this.setPatternTexture(patternTexture);
+		this.xRay = xRay;
 
 		/**
 		 * The main scene.
@@ -194,10 +189,8 @@ export class OutlineEffect extends Effect {
 		 * @private
 		 */
 
-		this.blurPass = new BlurPass(settings);
-
-		this.kernelSize = settings.kernelSize;
-		this.blur = settings.blur;
+		this.blurPass = new BlurPass({ resolutionScale, kernelSize });
+		this.blur = blur;
 
 		/**
 		 * The original resolution.
@@ -215,7 +208,7 @@ export class OutlineEffect extends Effect {
 		 * @private
 		 */
 
-		this.outlineEdgesPass = new ShaderPass(new OutlineEdgesMaterial(settings));
+		this.outlineEdgesPass = new ShaderPass(new OutlineEdgesMaterial());
 		this.outlineEdgesPass.getFullscreenMaterial().uniforms.maskTexture.value = this.renderTargetMask.texture;
 
 		/**
@@ -242,7 +235,7 @@ export class OutlineEffect extends Effect {
 		 * @type {Number}
 		 */
 
-		this.pulseSpeed = settings.pulseSpeed;
+		this.pulseSpeed = pulseSpeed;
 
 		/**
 		 * A dedicated render layer for selected objects.
@@ -308,7 +301,7 @@ export class OutlineEffect extends Effect {
 	 * @type {KernelSize}
 	 */
 
-	set kernelSize(value = KernelSize.VERY_SMALL) {
+	set kernelSize(value) {
 
 		this.blurPass.kernelSize = value;
 
@@ -606,7 +599,6 @@ export class OutlineEffect extends Effect {
 		} else if(this.clear) {
 
 			this.clearPass.render(renderer, this.renderTargetMask);
-
 			this.clear = false;
 
 		}

--- a/src/effects/OutlineEffect.js
+++ b/src/effects/OutlineEffect.js
@@ -554,10 +554,10 @@ export class OutlineEffect extends Effect {
 	 *
 	 * @param {WebGLRenderer} renderer - The renderer.
 	 * @param {WebGLRenderTarget} inputBuffer - A frame buffer that contains the result of the previous pass.
-	 * @param {Number} [delta] - The time between the last frame and the current one in seconds.
+	 * @param {Number} [deltaTime] - The time between the last frame and the current one in seconds.
 	 */
 
-	update(renderer, inputBuffer, delta) {
+	update(renderer, inputBuffer, deltaTime) {
 
 		const mainScene = this.mainScene;
 		const mainCamera = this.mainCamera;
@@ -574,7 +574,7 @@ export class OutlineEffect extends Effect {
 			if(this.pulseSpeed > 0.0) {
 
 				pulse.value = 0.625 + Math.cos(this.time * this.pulseSpeed * 10.0) * 0.375;
-				this.time += delta;
+				this.time += deltaTime;
 
 			}
 

--- a/src/effects/RealisticBokehEffect.js
+++ b/src/effects/RealisticBokehEffect.js
@@ -34,46 +34,44 @@ export class RealisticBokehEffect extends Effect {
 	 * @param {Boolean} [options.pentagon=false] - Enables pentagonal blur shapes. Requires a high number of rings and samples.
 	 */
 
-	constructor(options = {}) {
-
-		const settings = Object.assign({
-			blendFunction: BlendFunction.NORMAL,
-			focus: 1.0,
-			focalLength: 24.0,
-			luminanceThreshold: 0.5,
-			luminanceGain: 2.0,
-			bias: 0.5,
-			fringe: 0.7,
-			maxBlur: 1.0,
-			rings: 3,
-			samples: 2,
-			showFocus: false,
-			manualDoF: false,
-			pentagon: false
-		}, options);
+	constructor({
+		blendFunction = BlendFunction.NORMAL,
+		focus = 1.0,
+		focalLength = 24.0,
+		luminanceThreshold = 0.5,
+		luminanceGain = 2.0,
+		bias = 0.5,
+		fringe = 0.7,
+		maxBlur = 1.0,
+		rings = 3,
+		samples = 2,
+		showFocus = false,
+		manualDoF = false,
+		pentagon = false
+	} = {}) {
 
 		super("RealisticBokehEffect", fragment, {
 
+			blendFunction,
 			attributes: EffectAttribute.CONVOLUTION | EffectAttribute.DEPTH,
-			blendFunction: settings.blendFunction,
 
 			uniforms: new Map([
-				["focus", new Uniform(settings.focus)],
-				["focalLength", new Uniform(settings.focalLength)],
-				["luminanceThreshold", new Uniform(settings.luminanceThreshold)],
-				["luminanceGain", new Uniform(settings.luminanceGain)],
-				["bias", new Uniform(settings.bias)],
-				["fringe", new Uniform(settings.fringe)],
-				["maxBlur", new Uniform(settings.maxBlur)]
+				["focus", new Uniform(focus)],
+				["focalLength", new Uniform(focalLength)],
+				["luminanceThreshold", new Uniform(luminanceThreshold)],
+				["luminanceGain", new Uniform(luminanceGain)],
+				["bias", new Uniform(bias)],
+				["fringe", new Uniform(fringe)],
+				["maxBlur", new Uniform(maxBlur)]
 			])
 
 		});
 
-		this.rings = settings.rings;
-		this.samples = settings.samples;
-		this.showFocus = settings.showFocus;
-		this.manualDoF = settings.manualDoF;
-		this.pentagon = settings.pentagon;
+		this.rings = rings;
+		this.samples = samples;
+		this.showFocus = showFocus;
+		this.manualDoF = manualDoF;
+		this.pentagon = pentagon;
 
 	}
 

--- a/src/effects/RealisticBokehEffect.js
+++ b/src/effects/RealisticBokehEffect.js
@@ -20,7 +20,7 @@ export class RealisticBokehEffect extends Effect {
 	 *
 	 * @param {Object} [options] - The options.
 	 * @param {BlendFunction} [options.blendFunction=BlendFunction.NORMAL] - The blend function of this effect.
-	 * @param {Number} [options.focus=0.5] - The focus distance ratio, ranging from 0.0 to 1.0.
+	 * @param {Number} [options.focus=1.0] - The focus distance in world units.
 	 * @param {Number} [options.focalLength=24.0] - The focal length of the main camera.
 	 * @param {Number} [options.luminanceThreshold=0.5] - A luminance threshold.
 	 * @param {Number} [options.luminanceGain=2.0] - A luminance gain factor.
@@ -38,7 +38,7 @@ export class RealisticBokehEffect extends Effect {
 
 		const settings = Object.assign({
 			blendFunction: BlendFunction.NORMAL,
-			focus: 0.5,
+			focus: 1.0,
 			focalLength: 24.0,
 			luminanceThreshold: 0.5,
 			luminanceGain: 2.0,

--- a/src/effects/SMAAEffect.js
+++ b/src/effects/SMAAEffect.js
@@ -89,10 +89,9 @@ export class SMAAEffect extends Effect {
 		 * @private
 		 */
 
-		this.clearPass = new ClearPass({
-			clearColor: new Color(0x000000),
-			clearAlpha: 1.0
-		});
+		this.clearPass = new ClearPass(true, false, false);
+		this.clearPass.overrideClearColor = new Color(0x000000);
+		this.clearPass.overrideClearAlpha = 1.0;
 
 		/**
 		 * A color edge detection pass.

--- a/src/effects/SMAAEffect.js
+++ b/src/effects/SMAAEffect.js
@@ -40,8 +40,8 @@ export class SMAAEffect extends Effect {
 
 		super("SMAAEffect", fragment, {
 
-			attributes: EffectAttribute.CONVOLUTION,
 			blendFunction: BlendFunction.NORMAL,
+			attributes: EffectAttribute.CONVOLUTION,
 
 			uniforms: new Map([
 				["weightMap", new Uniform(null)]
@@ -60,9 +60,9 @@ export class SMAAEffect extends Effect {
 
 		this.renderTargetColorEdges = new WebGLRenderTarget(1, 1, {
 			minFilter: LinearFilter,
-			format: RGBFormat,
 			stencilBuffer: false,
-			depthBuffer: false
+			depthBuffer: false,
+			format: RGBFormat
 		});
 
 		this.renderTargetColorEdges.texture.name = "SMAA.ColorEdges";

--- a/src/effects/SMAAEffect.js
+++ b/src/effects/SMAAEffect.js
@@ -66,7 +66,6 @@ export class SMAAEffect extends Effect {
 		});
 
 		this.renderTargetColorEdges.texture.name = "SMAA.ColorEdges";
-		this.renderTargetColorEdges.texture.generateMipmaps = false;
 
 		/**
 		 * A render target for the SMAA weights.

--- a/src/effects/SMAAEffect.js
+++ b/src/effects/SMAAEffect.js
@@ -177,10 +177,10 @@ export class SMAAEffect extends Effect {
 	 *
 	 * @param {WebGLRenderer} renderer - The renderer.
 	 * @param {WebGLRenderTarget} inputBuffer - A frame buffer that contains the result of the previous pass.
-	 * @param {Number} [delta] - The time between the last frame and the current one in seconds.
+	 * @param {Number} [deltaTime] - The time between the last frame and the current one in seconds.
 	 */
 
-	update(renderer, inputBuffer, delta) {
+	update(renderer, inputBuffer, deltaTime) {
 
 		this.clearPass.render(renderer, this.renderTargetColorEdges);
 		this.colorEdgesPass.render(renderer, inputBuffer, this.renderTargetColorEdges);

--- a/src/effects/SSAOEffect.js
+++ b/src/effects/SSAOEffect.js
@@ -35,26 +35,24 @@ export class SSAOEffect extends Effect {
 	 * @param {Number} [options.bias=0.5] - An occlusion bias.
 	 */
 
-	constructor(camera, normalBuffer, options = {}) {
-
-		const settings = Object.assign({
-			blendFunction: BlendFunction.MULTIPLY,
-			samples: 11,
-			rings: 4,
-			distanceThreshold: 0.65,
-			distanceFalloff: 0.1,
-			rangeThreshold: 0.0015,
-			rangeFalloff: 0.01,
-			luminanceInfluence: 0.7,
-			radius: 18.25,
-			scale: 1.0,
-			bias: 0.5
-		}, options);
+	constructor(camera, normalBuffer, {
+		blendFunction = BlendFunction.MULTIPLY,
+		samples = 11,
+		rings = 4,
+		distanceThreshold = 0.65,
+		distanceFalloff = 0.1,
+		rangeThreshold = 0.0015,
+		rangeFalloff = 0.01,
+		luminanceInfluence = 0.7,
+		radius = 18.25,
+		scale = 1.0,
+		bias = 0.5
+	} = {}) {
 
 		super("SSAOEffect", fragment, {
 
+			blendFunction,
 			attributes: EffectAttribute.DEPTH,
-			blendFunction: settings.blendFunction,
 
 			defines: new Map([
 				["RINGS_INT", "0"],
@@ -70,9 +68,9 @@ export class SSAOEffect extends Effect {
 				["distanceCutoff", new Uniform(new Vector2())],
 				["proximityCutoff", new Uniform(new Vector2())],
 				["seed", new Uniform(Math.random())],
-				["luminanceInfluence", new Uniform(settings.luminanceInfluence)],
-				["scale", new Uniform(settings.scale)],
-				["bias", new Uniform(settings.bias)]
+				["luminanceInfluence", new Uniform(luminanceInfluence)],
+				["scale", new Uniform(scale)],
+				["bias", new Uniform(bias)]
 			])
 
 		});
@@ -104,12 +102,12 @@ export class SSAOEffect extends Effect {
 
 		this.camera = camera;
 
-		this.samples = settings.samples;
-		this.rings = settings.rings;
-		this.radius = settings.radius;
+		this.samples = samples;
+		this.rings = rings;
+		this.radius = radius;
 
-		this.setDistanceCutoff(settings.distanceThreshold, settings.distanceFalloff);
-		this.setProximityCutoff(settings.rangeThreshold, settings.rangeFalloff);
+		this.setDistanceCutoff(distanceThreshold, distanceFalloff);
+		this.setProximityCutoff(rangeThreshold, rangeFalloff);
 
 	}
 

--- a/src/effects/SSAOEffect.js
+++ b/src/effects/SSAOEffect.js
@@ -7,12 +7,10 @@ import fragment from "./glsl/ssao/shader.frag";
 /**
  * A Screen Space Ambient Occlusion (SSAO) effect.
  *
- * SSAO is a method to approximate ambient occlusion in screen space.
- *
  * For high quality visuals use two SSAO effect instances in a row with
  * different radii, one for rough AO and one for fine details.
  *
- * This implementation uses a discrete spiral sampling pattern:
+ * This implementation uses a spiral sampling pattern:
  *  https://jsfiddle.net/a16ff1p7
  */
 

--- a/src/effects/ScanlineEffect.js
+++ b/src/effects/ScanlineEffect.js
@@ -18,16 +18,11 @@ export class ScanlineEffect extends Effect {
 	 * @param {Number} [options.density=1.25] - The scanline density.
 	 */
 
-	constructor(options = {}) {
-
-		const settings = Object.assign({
-			blendFunction: BlendFunction.OVERLAY,
-			density: 1.25
-		}, options);
+	constructor({ blendFunction = BlendFunction.OVERLAY, density = 1.25 } = {}) {
 
 		super("ScanlineEffect", fragment, {
 
-			blendFunction: settings.blendFunction,
+			blendFunction,
 
 			uniforms: new Map([
 				["count", new Uniform(0.0)]
@@ -51,7 +46,7 @@ export class ScanlineEffect extends Effect {
 		 * @private
 		 */
 
-		this.density = settings.density;
+		this.density = density;
 
 	}
 

--- a/src/effects/SepiaEffect.js
+++ b/src/effects/SepiaEffect.js
@@ -18,19 +18,14 @@ export class SepiaEffect extends Effect {
 	 * @param {Number} [options.intensity=1.0] - The intensity of the effect.
 	 */
 
-	constructor(options = {}) {
-
-		const settings = Object.assign({
-			blendFunction: BlendFunction.NORMAL,
-			intensity: 1.0
-		}, options);
+	constructor({ blendFunction = BlendFunction.NORMAL, intensity = 1.0 } = {}) {
 
 		super("SepiaEffect", fragment, {
 
-			blendFunction: settings.blendFunction,
+			blendFunction,
 
 			uniforms: new Map([
-				["intensity", new Uniform(settings.intensity)]
+				["intensity", new Uniform(intensity)]
 			])
 
 		});

--- a/src/effects/ShockWaveEffect.js
+++ b/src/effects/ShockWaveEffect.js
@@ -54,14 +54,12 @@ export class ShockWaveEffect extends Effect {
 	 * @param {Number} [options.amplitude=0.05] - The distortion amplitude.
 	 */
 
-	constructor(camera, epicenter = new Vector3(), options = {}) {
-
-		const settings = Object.assign({
-			speed: 2.0,
-			maxRadius: 1.0,
-			waveSize: 0.2,
-			amplitude: 0.05
-		}, options);
+	constructor(camera, epicenter = new Vector3(), {
+		speed = 2.0,
+		maxRadius = 1.0,
+		waveSize = 0.2,
+		amplitude = 0.05
+	} = {}) {
 
 		super("ShockWaveEffect", fragment, {
 
@@ -70,10 +68,10 @@ export class ShockWaveEffect extends Effect {
 				["center", new Uniform(new Vector2(0.5, 0.5))],
 				["cameraDistance", new Uniform(1.0)],
 				["size", new Uniform(1.0)],
-				["radius", new Uniform(-settings.waveSize)],
-				["maxRadius", new Uniform(settings.maxRadius)],
-				["waveSize", new Uniform(settings.waveSize)],
-				["amplitude", new Uniform(settings.amplitude)]
+				["radius", new Uniform(-waveSize)],
+				["maxRadius", new Uniform(maxRadius)],
+				["waveSize", new Uniform(waveSize)],
+				["amplitude", new Uniform(amplitude)]
 			]),
 
 			vertexShader: vertex
@@ -112,7 +110,7 @@ export class ShockWaveEffect extends Effect {
 		 * @type {Number}
 		 */
 
-		this.speed = settings.speed;
+		this.speed = speed;
 
 		/**
 		 * A time accumulator.

--- a/src/effects/TextureEffect.js
+++ b/src/effects/TextureEffect.js
@@ -20,25 +20,19 @@ export class TextureEffect extends Effect {
 	 * @param {Boolean} [options.aspectCorrection=false] - Whether the texture coordinates should be affected by the aspect ratio.
 	 */
 
-	constructor(options = {}) {
-
-		const settings = Object.assign({
-			blendFunction: BlendFunction.NORMAL,
-			texture: null,
-			aspectCorrection: false
-		}, options);
+	constructor({ blendFunction = BlendFunction.NORMAL, texture = null, aspectCorrection = false } = {}) {
 
 		super("TextureEffect", fragment, {
 
-			blendFunction: settings.blendFunction,
+			blendFunction,
 
 			uniforms: new Map([
-				["texture", new Uniform(settings.texture)]
+				["texture", new Uniform(texture)]
 			])
 
 		});
 
-		this.aspectCorrection = settings.aspectCorrection;
+		this.aspectCorrection = aspectCorrection;
 
 	}
 

--- a/src/effects/ToneMappingEffect.js
+++ b/src/effects/ToneMappingEffect.js
@@ -265,10 +265,10 @@ export class ToneMappingEffect extends Effect {
 	 *
 	 * @param {WebGLRenderer} renderer - The renderer.
 	 * @param {WebGLRenderTarget} inputBuffer - A frame buffer that contains the result of the previous pass.
-	 * @param {Number} [delta] - The time between the last frame and the current one in seconds.
+	 * @param {Number} [deltaTime] - The time between the last frame and the current one in seconds.
 	 */
 
-	update(renderer, inputBuffer, delta) {
+	update(renderer, inputBuffer, deltaTime) {
 
 		if(this.adaptive) {
 
@@ -279,7 +279,7 @@ export class ToneMappingEffect extends Effect {
 			const uniforms = this.adaptiveLuminancePass.getFullscreenMaterial().uniforms;
 			uniforms.previousLuminanceBuffer.value = this.renderTargetPrevious.texture;
 			uniforms.currentLuminanceBuffer.value = this.renderTargetLuminance.texture;
-			uniforms.delta.value = delta;
+			uniforms.deltaTime.value = deltaTime;
 			this.adaptiveLuminancePass.render(renderer, null, this.renderTargetAdapted);
 
 			// Save the adapted luminance for the next frame.

--- a/src/effects/ToneMappingEffect.js
+++ b/src/effects/ToneMappingEffect.js
@@ -42,28 +42,26 @@ export class ToneMappingEffect extends Effect {
 	 * @param {Number} [options.adaptationRate=1.0] - The luminance adaptation rate.
 	 */
 
-	constructor(options = {}) {
-
-		const settings = Object.assign({
-			blendFunction: BlendFunction.NORMAL,
-			adaptive: true,
-			resolution: 256,
-			distinction: 1.0,
-			middleGrey: 0.6,
-			maxLuminance: 16.0,
-			averageLuminance: 1.0,
-			adaptationRate: 2.0
-		}, options);
+	constructor({
+		blendFunction = BlendFunction.NORMAL,
+		adaptive = true,
+		resolution = 256,
+		distinction = 1.0,
+		middleGrey = 0.6,
+		maxLuminance = 16.0,
+		averageLuminance = 1.0,
+		adaptationRate = 2.0
+	} = {}) {
 
 		super("ToneMappingEffect", fragment, {
 
-			blendFunction: settings.blendFunction,
+			blendFunction,
 
 			uniforms: new Map([
 				["luminanceMap", new Uniform(null)],
-				["middleGrey", new Uniform(settings.middleGrey)],
-				["maxLuminance", new Uniform(settings.maxLuminance)],
-				["averageLuminance", new Uniform(settings.averageLuminance)]
+				["middleGrey", new Uniform(middleGrey)],
+				["maxLuminance", new Uniform(maxLuminance)],
+				["averageLuminance", new Uniform(averageLuminance)]
 			])
 
 		});
@@ -79,9 +77,9 @@ export class ToneMappingEffect extends Effect {
 		this.renderTargetLuminance = new WebGLRenderTarget(1, 1, {
 			minFilter: LinearMipMapLinearFilter,
 			magFilter: LinearFilter,
-			format: RGBFormat,
 			stencilBuffer: false,
-			depthBuffer: false
+			depthBuffer: false,
+			format: RGBFormat
 		});
 
 		this.renderTargetLuminance.texture.name = "ToneMapping.Luminance";
@@ -95,7 +93,6 @@ export class ToneMappingEffect extends Effect {
 		 */
 
 		this.renderTargetAdapted = this.renderTargetLuminance.clone();
-
 		this.renderTargetAdapted.texture.name = "ToneMapping.AdaptedLuminance";
 		this.renderTargetAdapted.texture.generateMipmaps = false;
 		this.renderTargetAdapted.texture.minFilter = LinearFilter;
@@ -108,7 +105,6 @@ export class ToneMappingEffect extends Effect {
 		 */
 
 		this.renderTargetPrevious = this.renderTargetAdapted.clone();
-
 		this.renderTargetPrevious.texture.name = "ToneMapping.PreviousLuminance";
 
 		/**
@@ -138,11 +134,10 @@ export class ToneMappingEffect extends Effect {
 
 		this.adaptiveLuminancePass = new ShaderPass(new AdaptiveLuminanceMaterial());
 
-		// Apply settings.
-		this.adaptationRate = settings.adaptationRate;
-		this.distinction = settings.distinction;
-		this.resolution = settings.resolution;
-		this.adaptive = settings.adaptive;
+		this.adaptationRate = adaptationRate;
+		this.distinction = distinction;
+		this.resolution = resolution;
+		this.adaptive = adaptive;
 
 	}
 

--- a/src/effects/ToneMappingEffect.js
+++ b/src/effects/ToneMappingEffect.js
@@ -110,7 +110,7 @@ export class ToneMappingEffect extends Effect {
 		/**
 		 * A save pass.
 		 *
-		 * @type {ShaderPass}
+		 * @type {SavePass}
 		 * @private
 		 */
 

--- a/src/effects/ToneMappingEffect.js
+++ b/src/effects/ToneMappingEffect.js
@@ -311,7 +311,8 @@ export class ToneMappingEffect extends Effect {
 
 	initialize(renderer, alpha) {
 
-		const clearPass = new ClearPass({ clearColor: new Color(0x7fffff) });
+		const clearPass = new ClearPass(true, false, false);
+		clearPass.overrideClearColor = new Color(0x7fffff);
 		clearPass.render(renderer, this.renderTargetPrevious);
 		clearPass.dispose();
 

--- a/src/effects/glsl/ssao/shader.frag
+++ b/src/effects/glsl/ssao/shader.frag
@@ -50,7 +50,6 @@ float getAmbientOcclusion(const in vec3 p, const in vec3 n, const in float depth
 	float angle = rand(uv + seed) * PI2;
 	float occlusionSum = 0.0;
 
-	// Collect samples along a discrete spiral pattern.
 	for(int i = 0; i < SAMPLES_INT; ++i) {
 
 		vec2 coord = uv + vec2(cos(angle), sin(angle)) * radius;

--- a/src/index.js
+++ b/src/index.js
@@ -50,6 +50,7 @@ export {
 	ConvolutionMaterial,
 	CopyMaterial,
 	DepthComparisonMaterial,
+	DepthMaskMaterial,
 	EffectMaterial,
 	GodRaysMaterial,
 	KernelSize,

--- a/src/materials/AdaptiveLuminanceMaterial.js
+++ b/src/materials/AdaptiveLuminanceMaterial.js
@@ -30,7 +30,7 @@ export class AdaptiveLuminanceMaterial extends ShaderMaterial {
 				previousLuminanceBuffer: new Uniform(null),
 				currentLuminanceBuffer: new Uniform(null),
 				minLuminance: new Uniform(0.01),
-				delta: new Uniform(0.0),
+				deltaTime: new Uniform(0.0),
 				tau: new Uniform(1.0)
 
 			},

--- a/src/materials/DepthMaskMaterial.js
+++ b/src/materials/DepthMaskMaterial.js
@@ -1,0 +1,42 @@
+import { ShaderMaterial, Uniform } from "three";
+
+import fragment from "./glsl/depth-mask/shader.frag";
+import vertex from "./glsl/common/shader.vert";
+
+/**
+ * A depth mask shader material.
+ *
+ * This material masks a color buffer by comparing two depth textures.
+ */
+
+export class DepthMaskMaterial extends ShaderMaterial {
+
+	/**
+	 * Constructs a new depth mask material.
+	 */
+
+	constructor() {
+
+		super({
+
+			type: "DepthMaskMaterial",
+
+			uniforms: {
+
+				depthBuffer0: new Uniform(null),
+				depthBuffer1: new Uniform(null),
+				inputBuffer: new Uniform(null)
+
+			},
+
+			fragmentShader: fragment,
+			vertexShader: vertex,
+
+			depthWrite: false,
+			depthTest: false
+
+		});
+
+	}
+
+}

--- a/src/materials/GodRaysMaterial.js
+++ b/src/materials/GodRaysMaterial.js
@@ -1,4 +1,4 @@
-import { ShaderMaterial, Uniform, Vector2 } from "three";
+import { ShaderMaterial, Uniform } from "three";
 
 import fragment from "./glsl/god-rays/shader.frag";
 import vertex from "./glsl/common/shader.vert";
@@ -24,24 +24,10 @@ export class GodRaysMaterial extends ShaderMaterial {
 	/**
 	 * Constructs a new god rays material.
 	 *
-	 * @param {Vector2} [lightPosition] - The light position in screen space.
-	 * @param {Object} [options] - The options.
-	 * @param {Number} [options.density=0.96] - The density of the light rays.
-	 * @param {Number} [options.decay=0.93] - An illumination decay factor.
-	 * @param {Number} [options.weight=0.4] - A light ray weight factor.
-	 * @param {Number} [options.exposure=0.6] - A constant attenuation coefficient.
-	 * @param {Number} [options.clampMax=1.0] - An upper bound for the saturation of the overall effect.
+	 * @param {Vector2} lightPosition - The light position in screen space.
 	 */
 
-	constructor(lightPosition = new Vector2(), options = {}) {
-
-		const settings = Object.assign({
-			exposure: 0.6,
-			density: 0.93,
-			decay: 0.96,
-			weight: 0.4,
-			clampMax: 1.0
-		}, options);
+	constructor(lightPosition) {
 
 		super({
 
@@ -59,11 +45,11 @@ export class GodRaysMaterial extends ShaderMaterial {
 				inputBuffer: new Uniform(null),
 				lightPosition: new Uniform(lightPosition),
 
-				exposure: new Uniform(settings.exposure),
-				decay: new Uniform(settings.decay),
-				density: new Uniform(settings.density),
-				weight: new Uniform(settings.weight),
-				clampMax: new Uniform(settings.clampMax)
+				density: new Uniform(1.0),
+				decay: new Uniform(1.0),
+				weight: new Uniform(1.0),
+				exposure: new Uniform(1.0),
+				clampMax: new Uniform(1.0)
 
 			},
 

--- a/src/materials/glsl/adaptive-luminance/shader.frag
+++ b/src/materials/glsl/adaptive-luminance/shader.frag
@@ -1,7 +1,7 @@
 uniform sampler2D previousLuminanceBuffer;
 uniform sampler2D currentLuminanceBuffer;
 uniform float minLuminance;
-uniform float delta;
+uniform float deltaTime;
 uniform float tau;
 
 varying vec2 vUv;
@@ -15,7 +15,7 @@ void main() {
 	currentLuminance = max(minLuminance, currentLuminance);
 
 	// Adapt the luminance using Pattanaik's technique.
-	float adaptedLum = previousLuminance + (currentLuminance - previousLuminance) * (1.0 - exp(-delta * tau));
+	float adaptedLum = previousLuminance + (currentLuminance - previousLuminance) * (1.0 - exp(-deltaTime * tau));
 
 	gl_FragColor.r = adaptedLum;
 

--- a/src/materials/glsl/depth-mask/shader.frag
+++ b/src/materials/glsl/depth-mask/shader.frag
@@ -1,0 +1,20 @@
+uniform sampler2D depthBuffer0;
+uniform sampler2D depthBuffer1;
+uniform sampler2D inputBuffer;
+
+varying vec2 vUv;
+
+void main() {
+
+	float d0 = texture2D(depthBuffer0, vUv).r;
+	float d1 = texture2D(depthBuffer1, vUv).r;
+
+	if(d0 < d1) {
+
+		discard;
+
+	}
+
+	gl_FragColor = texture2D(inputBuffer, vUv);
+
+}

--- a/src/materials/index.js
+++ b/src/materials/index.js
@@ -3,6 +3,7 @@ export { ColorEdgesMaterial } from "./ColorEdgesMaterial.js";
 export { ConvolutionMaterial, KernelSize } from "./ConvolutionMaterial.js";
 export { CopyMaterial } from "./CopyMaterial.js";
 export { DepthComparisonMaterial } from "./DepthComparisonMaterial.js";
+export { DepthMaskMaterial } from "./DepthMaskMaterial.js";
 export { EffectMaterial, Section } from "./EffectMaterial.js";
 export { GodRaysMaterial } from "./GodRaysMaterial.js";
 export { LuminanceMaterial } from "./LuminanceMaterial.js";

--- a/src/passes/BlurPass.js
+++ b/src/passes/BlurPass.js
@@ -207,7 +207,8 @@ export class BlurPass extends Pass {
 
 			uniforms.kernel.value = kernel[i];
 			uniforms.inputBuffer.value = lastRT.texture;
-			renderer.render(scene, camera, destRT);
+			renderer.setRenderTarget(destRT);
+			renderer.render(scene, camera);
 
 			lastRT = destRT;
 
@@ -223,7 +224,8 @@ export class BlurPass extends Pass {
 
 		uniforms.kernel.value = kernel[i];
 		uniforms.inputBuffer.value = lastRT.texture;
-		renderer.render(scene, camera, this.renderToScreen ? null : outputBuffer);
+		renderer.setRenderTarget(this.renderToScreen ? null : outputBuffer);
+		renderer.render(scene, camera);
 
 	}
 

--- a/src/passes/BlurPass.js
+++ b/src/passes/BlurPass.js
@@ -177,11 +177,11 @@ export class BlurPass extends Pass {
 	 * @param {WebGLRenderer} renderer - The renderer.
 	 * @param {WebGLRenderTarget} inputBuffer - A frame buffer that contains the result of the previous pass.
 	 * @param {WebGLRenderTarget} outputBuffer - A frame buffer that serves as the output render target unless this pass renders to screen.
-	 * @param {Number} [delta] - The time between the last frame and the current one in seconds.
+	 * @param {Number} [deltaTime] - The time between the last frame and the current one in seconds.
 	 * @param {Boolean} [stencilTest] - Indicates whether a stencil mask is active.
 	 */
 
-	render(renderer, inputBuffer, outputBuffer, delta, stencilTest) {
+	render(renderer, inputBuffer, outputBuffer, deltaTime, stencilTest) {
 
 		const scene = this.scene;
 		const camera = this.camera;

--- a/src/passes/BlurPass.js
+++ b/src/passes/BlurPass.js
@@ -18,7 +18,7 @@ export class BlurPass extends Pass {
 	 * @param {KernelSize} [options.kernelSize=KernelSize.LARGE] - The blur kernel size.
 	 */
 
-	constructor(options = {}) {
+	constructor({ resolutionScale = 0.5, kernelSize = KernelSize.LARGE } = {}) {
 
 		super("BlurPass");
 
@@ -37,7 +37,6 @@ export class BlurPass extends Pass {
 		});
 
 		this.renderTargetX.texture.name = "Blur.TargetX";
-		this.renderTargetX.texture.generateMipmaps = false;
 
 		/**
 		 * A second render target.
@@ -65,7 +64,7 @@ export class BlurPass extends Pass {
 		 * @private
 		 */
 
-		this.resolutionScale = (options.resolutionScale !== undefined) ? options.resolutionScale : 0.5;
+		this.resolutionScale = resolutionScale;
 
 		/**
 		 * A convolution shader material.
@@ -94,7 +93,7 @@ export class BlurPass extends Pass {
 
 		this.dithering = false;
 
-		this.kernelSize = options.kernelSize;
+		this.kernelSize = kernelSize;
 
 	}
 
@@ -135,10 +134,12 @@ export class BlurPass extends Pass {
 	}
 
 	/**
+	 * Sets the kernel size.
+	 *
 	 * @type {KernelSize}
 	 */
 
-	set kernelSize(value = KernelSize.LARGE) {
+	set kernelSize(value) {
 
 		this.convolutionMaterial.kernelSize = value;
 		this.ditheredConvolutionMaterial.kernelSize = value;

--- a/src/passes/BlurPass.js
+++ b/src/passes/BlurPass.js
@@ -14,8 +14,8 @@ export class BlurPass extends Pass {
 	 * Constructs a new blur pass.
 	 *
 	 * @param {Object} [options] - The options.
-	 * @param {Number} [options.resolutionScale=0.5] - The render texture resolution scale, relative to the screen render size.
-	 * @param {Number} [options.kernelSize=KernelSize.LARGE] - The blur kernel size.
+	 * @param {Number} [options.resolutionScale=0.5] - The render texture resolution scale, relative to the main frame buffer size.
+	 * @param {KernelSize} [options.kernelSize=KernelSize.LARGE] - The blur kernel size.
 	 */
 
 	constructor(options = {}) {

--- a/src/passes/ClearMaskPass.js
+++ b/src/passes/ClearMaskPass.js
@@ -24,11 +24,11 @@ export class ClearMaskPass extends Pass {
 	 * @param {WebGLRenderer} renderer - The renderer.
 	 * @param {WebGLRenderTarget} inputBuffer - A frame buffer that contains the result of the previous pass.
 	 * @param {WebGLRenderTarget} outputBuffer - A frame buffer that serves as the output render target unless this pass renders to screen.
-	 * @param {Number} [delta] - The time between the last frame and the current one in seconds.
+	 * @param {Number} [deltaTime] - The time between the last frame and the current one in seconds.
 	 * @param {Boolean} [stencilTest] - Indicates whether a stencil mask is active.
 	 */
 
-	render(renderer, inputBuffer, outputBuffer, delta, stencilTest) {
+	render(renderer, inputBuffer, outputBuffer, deltaTime, stencilTest) {
 
 		renderer.state.buffers.stencil.setTest(false);
 

--- a/src/passes/ClearPass.js
+++ b/src/passes/ClearPass.js
@@ -12,10 +12,6 @@ const color = new Color();
 
 /**
  * A pass that clears the input buffer or the screen.
- *
- * You can prevent specific bits from being cleared by setting either the
- * autoClearColor, autoClearStencil or autoClearDepth properties of the renderer
- * to false.
  */
 
 export class ClearPass extends Pass {
@@ -24,31 +20,66 @@ export class ClearPass extends Pass {
 	 * Constructs a new clear pass.
 	 *
 	 * @param {Object} [options] - Additional options.
+	 * @param {Boolean} [options.color=true] - Determines whether the color buffer should be cleared.
+	 * @param {Boolean} [options.depth=true] - Determines whether the depth buffer should be cleared.
+	 * @param {Boolean} [options.stencil=true] - Determines whether the stencil buffer should be cleared.
 	 * @param {Color} [options.clearColor=null] - An override clear color.
 	 * @param {Number} [options.clearAlpha=0.0] - An override clear alpha.
 	 */
 
 	constructor(options = {}) {
 
+		const settings = Object.assign({
+			color: true,
+			depth: true,
+			stencil: true,
+			clearColor: null,
+			clearAlpha: 0.0
+		}, options);
+
 		super("ClearPass", null, null);
 
 		this.needsSwap = false;
 
 		/**
-		 * The clear color.
+		 * Indicates whether the color buffer should be cleared.
+		 *
+		 * @type {Boolean}
+		 */
+
+		this.color = settings.color;
+
+		/**
+		 * Indicates whether the depth buffer should be cleared.
+		 *
+		 * @type {Boolean}
+		 */
+
+		this.depth = settings.depth;
+
+		/**
+		 * Indicates whether the stencil buffer should be cleared.
+		 *
+		 * @type {Boolean}
+		 */
+
+		this.stencil = settings.stencil;
+
+		/**
+		 * An override clear color.
 		 *
 		 * @type {Color}
 		 */
 
-		this.clearColor = (options.clearColor !== undefined) ? options.clearColor : null;
+		this.clearColor = settings.clearColor;
 
 		/**
-		 * The clear alpha.
+		 * An override clear alpha.
 		 *
 		 * @type {Number}
 		 */
 
-		this.clearAlpha = (options.clearAlpha !== undefined) ? options.clearAlpha : 0.0;
+		this.clearAlpha = settings.clearAlpha;
 
 	}
 
@@ -77,7 +108,7 @@ export class ClearPass extends Pass {
 		}
 
 		renderer.setRenderTarget(this.renderToScreen ? null : inputBuffer);
-		renderer.clear();
+		renderer.clear(this.color, this.depth, this.stencil);
 
 		if(clearColor !== null) {
 

--- a/src/passes/ClearPass.js
+++ b/src/passes/ClearPass.js
@@ -89,11 +89,11 @@ export class ClearPass extends Pass {
 	 * @param {WebGLRenderer} renderer - The renderer.
 	 * @param {WebGLRenderTarget} inputBuffer - A frame buffer that contains the result of the previous pass.
 	 * @param {WebGLRenderTarget} outputBuffer - A frame buffer that serves as the output render target unless this pass renders to screen.
-	 * @param {Number} [delta] - The time between the last frame and the current one in seconds.
+	 * @param {Number} [deltaTime] - The time between the last frame and the current one in seconds.
 	 * @param {Boolean} [stencilTest] - Indicates whether a stencil mask is active.
 	 */
 
-	render(renderer, inputBuffer, outputBuffer, delta, stencilTest) {
+	render(renderer, inputBuffer, outputBuffer, deltaTime, stencilTest) {
 
 		const clearColor = this.clearColor;
 

--- a/src/passes/ClearPass.js
+++ b/src/passes/ClearPass.js
@@ -19,23 +19,12 @@ export class ClearPass extends Pass {
 	/**
 	 * Constructs a new clear pass.
 	 *
-	 * @param {Object} [options] - Additional options.
-	 * @param {Boolean} [options.color=true] - Determines whether the color buffer should be cleared.
-	 * @param {Boolean} [options.depth=true] - Determines whether the depth buffer should be cleared.
-	 * @param {Boolean} [options.stencil=true] - Determines whether the stencil buffer should be cleared.
-	 * @param {Color} [options.clearColor=null] - An override clear color.
-	 * @param {Number} [options.clearAlpha=0.0] - An override clear alpha.
+	 * @param {Boolean} [color=true] - Determines whether the color buffer should be cleared.
+	 * @param {Boolean} [depth=true] - Determines whether the depth buffer should be cleared.
+	 * @param {Boolean} [stencil=false] - Determines whether the stencil buffer should be cleared.
 	 */
 
-	constructor(options = {}) {
-
-		const settings = Object.assign({
-			color: true,
-			depth: true,
-			stencil: true,
-			clearColor: null,
-			clearAlpha: 0.0
-		}, options);
+	constructor(color = true, depth = true, stencil = false) {
 
 		super("ClearPass", null, null);
 
@@ -47,7 +36,7 @@ export class ClearPass extends Pass {
 		 * @type {Boolean}
 		 */
 
-		this.color = settings.color;
+		this.color = color;
 
 		/**
 		 * Indicates whether the depth buffer should be cleared.
@@ -55,7 +44,7 @@ export class ClearPass extends Pass {
 		 * @type {Boolean}
 		 */
 
-		this.depth = settings.depth;
+		this.depth = depth;
 
 		/**
 		 * Indicates whether the stencil buffer should be cleared.
@@ -63,7 +52,7 @@ export class ClearPass extends Pass {
 		 * @type {Boolean}
 		 */
 
-		this.stencil = settings.stencil;
+		this.stencil = stencil;
 
 		/**
 		 * An override clear color.
@@ -71,7 +60,7 @@ export class ClearPass extends Pass {
 		 * @type {Color}
 		 */
 
-		this.clearColor = settings.clearColor;
+		this.overrideClearColor = null;
 
 		/**
 		 * An override clear alpha.
@@ -79,7 +68,7 @@ export class ClearPass extends Pass {
 		 * @type {Number}
 		 */
 
-		this.clearAlpha = settings.clearAlpha;
+		this.overrideClearAlpha = 0.0;
 
 	}
 
@@ -95,22 +84,22 @@ export class ClearPass extends Pass {
 
 	render(renderer, inputBuffer, outputBuffer, deltaTime, stencilTest) {
 
-		const clearColor = this.clearColor;
+		const overrideClearColor = this.overrideClearColor;
 
 		let clearAlpha;
 
-		if(clearColor !== null) {
+		if(overrideClearColor !== null) {
 
 			color.copy(renderer.getClearColor());
 			clearAlpha = renderer.getClearAlpha();
-			renderer.setClearColor(clearColor, this.clearAlpha);
+			renderer.setClearColor(overrideClearColor, this.overrideClearAlpha);
 
 		}
 
 		renderer.setRenderTarget(this.renderToScreen ? null : inputBuffer);
 		renderer.clear(this.color, this.depth, this.stencil);
 
-		if(clearColor !== null) {
+		if(overrideClearColor !== null) {
 
 			renderer.setClearColor(color, clearAlpha);
 

--- a/src/passes/DepthPass.js
+++ b/src/passes/DepthPass.js
@@ -127,7 +127,7 @@ export class DepthPass extends Pass {
 	render(renderer, inputBuffer, outputBuffer, deltaTime, stencilTest) {
 
 		const renderTarget = this.renderToScreen ? null : this.renderTarget;
-		this.renderPass.render(renderer, renderTarget, renderTarget);
+		this.renderPass.render(renderer, renderTarget);
 
 	}
 

--- a/src/passes/DepthPass.js
+++ b/src/passes/DepthPass.js
@@ -26,7 +26,7 @@ export class DepthPass extends Pass {
 	 * @param {WebGLRenderTarget} [options.renderTarget] - A custom render target.
 	 */
 
-	constructor(scene, camera, options = {}) {
+	constructor(scene, camera, { resolutionScale = 1.0, renderTarget } = {}) {
 
 		super("DepthPass");
 
@@ -55,7 +55,7 @@ export class DepthPass extends Pass {
 		 * @type {WebGLRenderTarget}
 		 */
 
-		this.renderTarget = options.renderTarget;
+		this.renderTarget = renderTarget;
 
 		if(this.renderTarget === undefined) {
 
@@ -70,6 +70,15 @@ export class DepthPass extends Pass {
 		}
 
 		/**
+		 * The current resolution scale.
+		 *
+		 * @type {Number}
+		 * @private
+		 */
+
+		this.resolutionScale = resolutionScale;
+
+		/**
 		 * The original resolution.
 		 *
 		 * @type {Vector2}
@@ -77,15 +86,6 @@ export class DepthPass extends Pass {
 		 */
 
 		this.resolution = new Vector2();
-
-		/**
-		 * The current resolution scale.
-		 *
-		 * @type {Number}
-		 * @private
-		 */
-
-		this.resolutionScale = (options.resolutionScale !== undefined) ? options.resolutionScale : 0.5;
 
 	}
 

--- a/src/passes/DepthPass.js
+++ b/src/passes/DepthPass.js
@@ -11,7 +11,7 @@ import { Pass } from "./Pass.js";
 import { RenderPass } from "./RenderPass.js";
 
 /**
- * A pass that renders the depth of a given scene.
+ * A pass that renders the depth of a given scene into a color buffer.
  */
 
 export class DepthPass extends Pass {
@@ -22,7 +22,7 @@ export class DepthPass extends Pass {
 	 * @param {Scene} scene - The scene to render.
 	 * @param {Camera} camera - The camera to use to render the scene.
 	 * @param {Object} [options] - The options.
-	 * @param {Number} [options.resolutionScale=0.5] - The render texture resolution scale, relative to the screen render size.
+	 * @param {Number} [options.resolutionScale=1.0] - The render texture resolution scale, relative to the main frame buffer size.
 	 * @param {WebGLRenderTarget} [options.renderTarget] - A custom render target.
 	 */
 

--- a/src/passes/DepthPass.js
+++ b/src/passes/DepthPass.js
@@ -120,11 +120,11 @@ export class DepthPass extends Pass {
 	 * @param {WebGLRenderer} renderer - The renderer.
 	 * @param {WebGLRenderTarget} inputBuffer - A frame buffer that contains the result of the previous pass.
 	 * @param {WebGLRenderTarget} outputBuffer - A frame buffer that serves as the output render target unless this pass renders to screen.
-	 * @param {Number} [delta] - The time between the last frame and the current one in seconds.
+	 * @param {Number} [deltaTime] - The time between the last frame and the current one in seconds.
 	 * @param {Boolean} [stencilTest] - Indicates whether a stencil mask is active.
 	 */
 
-	render(renderer, inputBuffer, outputBuffer, delta, stencilTest) {
+	render(renderer, inputBuffer, outputBuffer, deltaTime, stencilTest) {
 
 		const renderTarget = this.renderToScreen ? null : this.renderTarget;
 		this.renderPass.render(renderer, renderTarget, renderTarget);

--- a/src/passes/DepthPass.js
+++ b/src/passes/DepthPass.js
@@ -61,11 +61,11 @@ export class DepthPass extends Pass {
 
 			this.renderTarget = new WebGLRenderTarget(1, 1, {
 				minFilter: LinearFilter,
-				magFilter: LinearFilter
+				magFilter: LinearFilter,
+				stencilBuffer: false
 			});
 
 			this.renderTarget.texture.name = "DepthPass.Target";
-			this.renderTarget.texture.generateMipmaps = false;
 
 		}
 

--- a/src/passes/DepthPass.js
+++ b/src/passes/DepthPass.js
@@ -39,15 +39,15 @@ export class DepthPass extends Pass {
 		 * @private
 		 */
 
-		this.renderPass = new RenderPass(scene, camera, {
-			overrideMaterial: new MeshDepthMaterial({
-				depthPacking: RGBADepthPacking,
-				morphTargets: true,
-				skinning: true
-			}),
-			clearColor: new Color(0xffffff),
-			clearAlpha: 1.0
-		});
+		this.renderPass = new RenderPass(scene, camera, new MeshDepthMaterial({
+			depthPacking: RGBADepthPacking,
+			morphTargets: true,
+			skinning: true
+		}));
+
+		const clearPass = this.renderPass.getClearPass();
+		clearPass.overrideClearColor = new Color(0xffffff);
+		clearPass.overrideClearAlpha = 1.0;
 
 		/**
 		 * A render target that contains the scene depth.

--- a/src/passes/EffectPass.js
+++ b/src/passes/EffectPass.js
@@ -525,8 +525,6 @@ export class EffectPass extends Pass {
 
 		}
 
-		this.needsDepthTexture = (depthTexture === null);
-
 	}
 
 	/**

--- a/src/passes/EffectPass.js
+++ b/src/passes/EffectPass.js
@@ -307,7 +307,7 @@ export class EffectPass extends Pass {
 	/**
 	 * Enables or disables dithering.
 	 *
-	 * Note that some effects like bloom have their own dithering setting.
+	 * Note that some effects have their own dithering setting.
 	 *
 	 * @type {Boolean}
 	 */

--- a/src/passes/EffectPass.js
+++ b/src/passes/EffectPass.js
@@ -554,7 +554,8 @@ export class EffectPass extends Pass {
 
 			material.uniforms.inputBuffer.value = inputBuffer.texture;
 			material.uniforms.time.value = (time <= this.maxTime) ? time : this.minTime;
-			renderer.render(this.scene, this.camera, this.renderToScreen ? null : outputBuffer);
+			renderer.setRenderTarget(this.renderToScreen ? null : outputBuffer);
+			renderer.render(this.scene, this.camera);
 
 		}
 

--- a/src/passes/EffectPass.js
+++ b/src/passes/EffectPass.js
@@ -533,18 +533,18 @@ export class EffectPass extends Pass {
 	 * @param {WebGLRenderer} renderer - The renderer.
 	 * @param {WebGLRenderTarget} inputBuffer - A frame buffer that contains the result of the previous pass.
 	 * @param {WebGLRenderTarget} outputBuffer - A frame buffer that serves as the output render target unless this pass renders to screen.
-	 * @param {Number} [delta] - The time between the last frame and the current one in seconds.
+	 * @param {Number} [deltaTime] - The time between the last frame and the current one in seconds.
 	 * @param {Boolean} [stencilTest] - Indicates whether a stencil mask is active.
 	 */
 
-	render(renderer, inputBuffer, outputBuffer, delta, stencilTest) {
+	render(renderer, inputBuffer, outputBuffer, deltaTime, stencilTest) {
 
 		const material = this.getFullscreenMaterial();
-		const time = material.uniforms.time.value + delta;
+		const time = material.uniforms.time.value + deltaTime;
 
 		for(const effect of this.effects) {
 
-			effect.update(renderer, inputBuffer, delta);
+			effect.update(renderer, inputBuffer, deltaTime);
 
 		}
 

--- a/src/passes/MaskPass.js
+++ b/src/passes/MaskPass.js
@@ -98,12 +98,15 @@ export class MaskPass extends Pass {
 		// Draw the mask.
 		if(this.renderToScreen) {
 
-			renderer.render(scene, camera, null);
+			renderer.setRenderTarget(null);
+			renderer.render(scene, camera);
 
 		} else {
 
-			renderer.render(scene, camera, inputBuffer);
-			renderer.render(scene, camera, outputBuffer);
+			renderer.setRenderTarget(inputBuffer);
+			renderer.render(scene, camera);
+			renderer.setRenderTarget(outputBuffer);
+			renderer.render(scene, camera);
 
 		}
 

--- a/src/passes/MaskPass.js
+++ b/src/passes/MaskPass.js
@@ -1,3 +1,4 @@
+import { ClearPass } from "./ClearPass.js";
 import { Pass } from "./Pass.js";
 
 /**
@@ -23,6 +24,15 @@ export class MaskPass extends Pass {
 		this.needsSwap = false;
 
 		/**
+		 * A clear pass.
+		 *
+		 * @type {ClearPass}
+		 * @private
+		 */
+
+		this.clearPass = new ClearPass(false, false, true);
+
+		/**
 		 * Inverse flag.
 		 *
 		 * @type {Boolean}
@@ -30,13 +40,29 @@ export class MaskPass extends Pass {
 
 		this.inverse = false;
 
-		/**
-		 * Stencil buffer clear flag.
-		 *
-		 * @type {Boolean}
-		 */
+	}
 
-		this.clearStencil = true;
+	/**
+	 * Indicates whether this pass should clear the stencil buffer.
+	 *
+	 * @type {Boolean}
+	 */
+
+	get clear() {
+
+		return this.clearPass.enabled;
+
+	}
+
+	/**
+	 * Enables or disables auto clear.
+	 *
+	 * @type {Boolean}
+	 */
+
+	set clear(value) {
+
+		this.clearPass.enabled = value;
 
 	}
 
@@ -57,6 +83,7 @@ export class MaskPass extends Pass {
 
 		const scene = this.scene;
 		const camera = this.camera;
+		const clearPass = this.clearPass;
 
 		const writeValue = this.inverse ? 0 : 1;
 		const clearValue = 1 - writeValue;
@@ -76,20 +103,16 @@ export class MaskPass extends Pass {
 		state.buffers.stencil.setClear(clearValue);
 
 		// Clear the stencil.
-		if(this.clearStencil) {
+		if(this.clear) {
 
 			if(this.renderToScreen) {
 
-				renderer.setRenderTarget(null);
-				renderer.clearStencil();
+				clearPass.render(renderer, null);
 
 			} else {
 
-				renderer.setRenderTarget(inputBuffer);
-				renderer.clearStencil();
-
-				renderer.setRenderTarget(outputBuffer);
-				renderer.clearStencil();
+				clearPass.render(renderer, inputBuffer);
+				clearPass.render(renderer, outputBuffer);
 
 			}
 

--- a/src/passes/MaskPass.js
+++ b/src/passes/MaskPass.js
@@ -46,11 +46,11 @@ export class MaskPass extends Pass {
 	 * @param {WebGLRenderer} renderer - The renderer.
 	 * @param {WebGLRenderTarget} inputBuffer - A frame buffer that contains the result of the previous pass.
 	 * @param {WebGLRenderTarget} outputBuffer - A frame buffer that serves as the output render target unless this pass renders to screen.
-	 * @param {Number} [delta] - The time between the last frame and the current one in seconds.
+	 * @param {Number} [deltaTime] - The time between the last frame and the current one in seconds.
 	 * @param {Boolean} [stencilTest] - Indicates whether a stencil mask is active.
 	 */
 
-	render(renderer, inputBuffer, outputBuffer, delta, stencilTest) {
+	render(renderer, inputBuffer, outputBuffer, deltaTime, stencilTest) {
 
 		const context = renderer.context;
 		const state = renderer.state;

--- a/src/passes/NormalPass.js
+++ b/src/passes/NormalPass.js
@@ -39,14 +39,14 @@ export class NormalPass extends Pass {
 		 * @private
 		 */
 
-		this.renderPass = new RenderPass(scene, camera, {
-			overrideMaterial: new MeshNormalMaterial({
-				morphTargets: true,
-				skinning: true
-			}),
-			clearColor: new Color(0x7777ff),
-			clearAlpha: 1.0
-		});
+		this.renderPass = new RenderPass(scene, camera, new MeshNormalMaterial({
+			morphTargets: true,
+			skinning: true
+		}));
+
+		const clearPass = this.renderPass.getClearPass();
+		clearPass.overrideClearColor = new Color(0x7777ff);
+		clearPass.overrideClearAlpha = 1.0;
 
 		/**
 		 * A render target that contains the scene normals.

--- a/src/passes/NormalPass.js
+++ b/src/passes/NormalPass.js
@@ -61,11 +61,11 @@ export class NormalPass extends Pass {
 			this.renderTarget = new WebGLRenderTarget(1, 1, {
 				minFilter: LinearFilter,
 				magFilter: LinearFilter,
-				format: RGBFormat
+				format: RGBFormat,
+				stencilBuffer: false
 			});
 
 			this.renderTarget.texture.name = "NormalPass.Target";
-			this.renderTarget.texture.generateMipmaps = false;
 
 		}
 

--- a/src/passes/NormalPass.js
+++ b/src/passes/NormalPass.js
@@ -120,11 +120,11 @@ export class NormalPass extends Pass {
 	 * @param {WebGLRenderer} renderer - The renderer.
 	 * @param {WebGLRenderTarget} inputBuffer - A frame buffer that contains the result of the previous pass.
 	 * @param {WebGLRenderTarget} outputBuffer - A frame buffer that serves as the output render target unless this pass renders to screen.
-	 * @param {Number} [delta] - The time between the last frame and the current one in seconds.
+	 * @param {Number} [deltaTime] - The time between the last frame and the current one in seconds.
 	 * @param {Boolean} [stencilTest] - Indicates whether a stencil mask is active.
 	 */
 
-	render(renderer, inputBuffer, outputBuffer, delta, stencilTest) {
+	render(renderer, inputBuffer, outputBuffer, deltaTime, stencilTest) {
 
 		const renderTarget = this.renderToScreen ? null : this.renderTarget;
 		this.renderPass.render(renderer, renderTarget, renderTarget);

--- a/src/passes/NormalPass.js
+++ b/src/passes/NormalPass.js
@@ -22,7 +22,7 @@ export class NormalPass extends Pass {
 	 * @param {Scene} scene - The scene to render.
 	 * @param {Camera} camera - The camera to use to render the scene.
 	 * @param {Object} [options] - The options.
-	 * @param {Number} [options.resolutionScale=0.5] - The render texture resolution scale, relative to the screen render size.
+	 * @param {Number} [options.resolutionScale=1.0] - The render texture resolution scale, relative to the main frame buffer size.
 	 * @param {WebGLRenderTarget} [options.renderTarget] - A custom render target.
 	 */
 

--- a/src/passes/NormalPass.js
+++ b/src/passes/NormalPass.js
@@ -26,7 +26,7 @@ export class NormalPass extends Pass {
 	 * @param {WebGLRenderTarget} [options.renderTarget] - A custom render target.
 	 */
 
-	constructor(scene, camera, options = {}) {
+	constructor(scene, camera, { resolutionScale = 1.0, renderTarget } = {}) {
 
 		super("NormalPass");
 
@@ -54,7 +54,7 @@ export class NormalPass extends Pass {
 		 * @type {WebGLRenderTarget}
 		 */
 
-		this.renderTarget = options.renderTarget;
+		this.renderTarget = renderTarget;
 
 		if(this.renderTarget === undefined) {
 
@@ -70,6 +70,15 @@ export class NormalPass extends Pass {
 		}
 
 		/**
+		 * The current resolution scale.
+		 *
+		 * @type {Number}
+		 * @private
+		 */
+
+		this.resolutionScale = resolutionScale;
+
+		/**
 		 * The original resolution.
 		 *
 		 * @type {Vector2}
@@ -77,15 +86,6 @@ export class NormalPass extends Pass {
 		 */
 
 		this.resolution = new Vector2();
-
-		/**
-		 * The current resolution scale.
-		 *
-		 * @type {Number}
-		 * @private
-		 */
-
-		this.resolutionScale = (options.resolutionScale !== undefined) ? options.resolutionScale : 0.5;
 
 	}
 

--- a/src/passes/Pass.js
+++ b/src/passes/Pass.js
@@ -65,6 +65,8 @@ export class Pass {
 		 * Set this to `false` if this pass doesn't render to the output buffer or
 		 * the screen. Otherwise, the contents of the input buffer will be lost.
 		 *
+		 * This flag must not be changed at runtime.
+		 *
 		 * @type {Boolean}
 		 */
 

--- a/src/passes/Pass.js
+++ b/src/passes/Pass.js
@@ -195,8 +195,8 @@ export class Pass {
 	/**
 	 * Updates this pass with the renderer's size.
 	 *
-	 * You may override this method in case you want to be informed about the main
-	 * render size.
+	 * You may override this method in case you want to be informed about the size
+	 * of the main frame buffer.
 	 *
 	 * The {@link EffectComposer} calls this method before this pass is
 	 * initialized and every time its own size is updated.

--- a/src/passes/Pass.js
+++ b/src/passes/Pass.js
@@ -182,11 +182,11 @@ export class Pass {
 	 * @param {WebGLRenderer} renderer - The renderer.
 	 * @param {WebGLRenderTarget} inputBuffer - A frame buffer that contains the result of the previous pass.
 	 * @param {WebGLRenderTarget} outputBuffer - A frame buffer that serves as the output render target unless this pass renders to screen.
-	 * @param {Number} [delta] - The time between the last frame and the current one in seconds.
+	 * @param {Number} [deltaTime] - The time between the last frame and the current one in seconds.
 	 * @param {Boolean} [stencilTest] - Indicates whether a stencil mask is active.
 	 */
 
-	render(renderer, inputBuffer, outputBuffer, delta, stencilTest) {
+	render(renderer, inputBuffer, outputBuffer, deltaTime, stencilTest) {
 
 		throw new Error("Render method not implemented!");
 

--- a/src/passes/RenderPass.js
+++ b/src/passes/RenderPass.js
@@ -94,7 +94,8 @@ export class RenderPass extends Pass {
 		}
 
 		scene.overrideMaterial = this.overrideMaterial;
-		renderer.render(scene, this.camera, renderTarget);
+		renderer.setRenderTarget(renderTarget);
+		renderer.render(scene, this.camera);
 		scene.overrideMaterial = overrideMaterial;
 
 	}

--- a/src/passes/RenderPass.js
+++ b/src/passes/RenderPass.js
@@ -40,8 +40,41 @@ export class RenderPass extends Pass {
 
 		this.clearPass = new ClearPass();
 
+	}
 
-		this.clear = (options.clear !== undefined) ? options.clear : true;
+	/**
+	 * Indicates whether the target buffer should be cleared before rendering.
+	 *
+	 * @type {Boolean}
+	 */
+
+	get clear() {
+
+		return this.clearPass.enabled;
+
+	}
+
+	/**
+	 * Enables or disables auto clear.
+	 *
+	 * @type {Boolean}
+	 */
+
+	set clear(value) {
+
+		this.clearPass.enabled = value;
+
+	}
+
+	/**
+	 * Returns the clear pass.
+	 *
+	 * @return {ClearPass} The clear pass.
+	 */
+
+	getClearPass() {
+
+		return this.clearPass;
 
 	}
 

--- a/src/passes/RenderPass.js
+++ b/src/passes/RenderPass.js
@@ -71,11 +71,11 @@ export class RenderPass extends Pass {
 	 * @param {WebGLRenderer} renderer - The renderer.
 	 * @param {WebGLRenderTarget} inputBuffer - A frame buffer that contains the result of the previous pass.
 	 * @param {WebGLRenderTarget} outputBuffer - A frame buffer that serves as the output render target unless this pass renders to screen.
-	 * @param {Number} [delta] - The time between the last frame and the current one in seconds.
+	 * @param {Number} [deltaTime] - The time between the last frame and the current one in seconds.
 	 * @param {Boolean} [stencilTest] - Indicates whether a stencil mask is active.
 	 */
 
-	render(renderer, inputBuffer, outputBuffer, delta, stencilTest) {
+	render(renderer, inputBuffer, outputBuffer, deltaTime, stencilTest) {
 
 		const scene = this.scene;
 		const renderTarget = this.renderToScreen ? null : inputBuffer;

--- a/src/passes/RenderPass.js
+++ b/src/passes/RenderPass.js
@@ -2,8 +2,9 @@ import { ClearPass } from "./ClearPass.js";
 import { Pass } from "./Pass.js";
 
 /**
- * A pass that renders a given scene directly on screen or into the read buffer
- * for further processing.
+ * A pass that renders a given scene into the input buffer or to screen.
+ *
+ * This pass uses a {@link ClearPass} to clear the target buffer.
  */
 
 export class RenderPass extends Pass {
@@ -13,27 +14,14 @@ export class RenderPass extends Pass {
 	 *
 	 * @param {Scene} scene - The scene to render.
 	 * @param {Camera} camera - The camera to use to render the scene.
-	 * @param {Object} [options] - Additional options.
-	 * @param {Material} [options.overrideMaterial=null] - An override material for the scene.
-	 * @param {Color} [options.clearColor=null] - An override clear color.
-	 * @param {Number} [options.clearAlpha=1.0] - An override clear alpha.
-	 * @param {Boolean} [options.clearDepth=false] - Whether depth should be cleared explicitly.
-	 * @param {Boolean} [options.clear=true] - Whether all buffers should be cleared.
+	 * @param {Object} [overrideMaterial=null] - An override material for the scene.
 	 */
 
-	constructor(scene, camera, options = {}) {
+	constructor(scene, camera, overrideMaterial = null) {
 
 		super("RenderPass", scene, camera);
 
 		this.needsSwap = false;
-
-		/**
-		 * A clear pass.
-		 *
-		 * @type {ClearPass}
-		 */
-
-		this.clearPass = new ClearPass(options);
 
 		/**
 		 * An override material.
@@ -41,25 +29,17 @@ export class RenderPass extends Pass {
 		 * @type {Material}
 		 */
 
-		this.overrideMaterial = (options.overrideMaterial !== undefined) ? options.overrideMaterial : null;
+		this.overrideMaterial = overrideMaterial;
 
 		/**
-		 * Indicates whether the depth buffer should be cleared explicitly.
+		 * A clear pass.
 		 *
-		 * @type {Boolean}
+		 * @type {ClearPass}
+		 * @private
 		 */
 
-		this.clearDepth = (options.clearDepth !== undefined) ? options.clearDepth : false;
+		this.clearPass = new ClearPass();
 
-		/**
-		 * Indicates whether the color, depth and stencil buffers should be cleared.
-		 *
-		 * Even with clear set to true you can prevent specific buffers from being
-		 * cleared by setting either the autoClearColor, autoClearStencil or
-		 * autoClearDepth properties of the renderer to false.
-		 *
-		 * @type {Boolean}
-		 */
 
 		this.clear = (options.clear !== undefined) ? options.clear : true;
 
@@ -85,11 +65,6 @@ export class RenderPass extends Pass {
 
 			this.clearPass.renderToScreen = this.renderToScreen;
 			this.clearPass.render(renderer, inputBuffer);
-
-		} else if(this.clearDepth) {
-
-			renderer.setRenderTarget(renderTarget);
-			renderer.clearDepth();
 
 		}
 

--- a/src/passes/SavePass.js
+++ b/src/passes/SavePass.js
@@ -69,7 +69,8 @@ export class SavePass extends Pass {
 
 		this.getFullscreenMaterial().uniforms.inputBuffer.value = inputBuffer.texture;
 
-		renderer.render(this.scene, this.camera, this.renderToScreen ? null : this.renderTarget);
+		renderer.setRenderTarget(this.renderToScreen ? null : this.renderTarget);
+		renderer.render(this.scene, this.camera);
 
 	}
 

--- a/src/passes/SavePass.js
+++ b/src/passes/SavePass.js
@@ -41,7 +41,6 @@ export class SavePass extends Pass {
 			});
 
 			this.renderTarget.texture.name = "SavePass.Target";
-			this.renderTarget.texture.generateMipmaps = false;
 
 		}
 

--- a/src/passes/SavePass.js
+++ b/src/passes/SavePass.js
@@ -61,11 +61,11 @@ export class SavePass extends Pass {
 	 * @param {WebGLRenderer} renderer - The renderer.
 	 * @param {WebGLRenderTarget} inputBuffer - A frame buffer that contains the result of the previous pass.
 	 * @param {WebGLRenderTarget} outputBuffer - A frame buffer that serves as the output render target unless this pass renders to screen.
-	 * @param {Number} [delta] - The time between the last frame and the current one in seconds.
+	 * @param {Number} [deltaTime] - The time between the last frame and the current one in seconds.
 	 * @param {Boolean} [stencilTest] - Indicates whether a stencil mask is active.
 	 */
 
-	render(renderer, inputBuffer, outputBuffer, delta, stencilTest) {
+	render(renderer, inputBuffer, outputBuffer, deltaTime, stencilTest) {
 
 		this.getFullscreenMaterial().uniforms.inputBuffer.value = inputBuffer.texture;
 

--- a/src/passes/ShaderPass.js
+++ b/src/passes/ShaderPass.js
@@ -56,7 +56,7 @@ export class ShaderPass extends Pass {
 
 			const uniforms = material.uniforms;
 
-			if(uniforms[input] !== undefined) {
+			if(uniforms !== undefined && uniforms[input] !== undefined) {
 
 				this.uniform = uniforms[input];
 

--- a/src/passes/ShaderPass.js
+++ b/src/passes/ShaderPass.js
@@ -84,7 +84,8 @@ export class ShaderPass extends Pass {
 
 		}
 
-		renderer.render(this.scene, this.camera, this.renderToScreen ? null : outputBuffer);
+		renderer.setRenderTarget(this.renderToScreen ? null : outputBuffer);
+		renderer.render(this.scene, this.camera);
 
 	}
 

--- a/src/passes/ShaderPass.js
+++ b/src/passes/ShaderPass.js
@@ -72,11 +72,11 @@ export class ShaderPass extends Pass {
 	 * @param {WebGLRenderer} renderer - The renderer.
 	 * @param {WebGLRenderTarget} inputBuffer - A frame buffer that contains the result of the previous pass.
 	 * @param {WebGLRenderTarget} outputBuffer - A frame buffer that serves as the output render target unless this pass renders to screen.
-	 * @param {Number} [delta] - The time between the last frame and the current one in seconds.
+	 * @param {Number} [deltaTime] - The time between the last frame and the current one in seconds.
 	 * @param {Boolean} [stencilTest] - Indicates whether a stencil mask is active.
 	 */
 
-	render(renderer, inputBuffer, outputBuffer, delta, stencilTest) {
+	render(renderer, inputBuffer, outputBuffer, deltaTime, stencilTest) {
 
 		if(this.uniform !== null) {
 

--- a/test/effects/GodRaysEffect.js
+++ b/test/effects/GodRaysEffect.js
@@ -3,7 +3,11 @@ import { GodRaysEffect } from "../../build/postprocessing.umd.js";
 
 test("can be created and destroyed", t => {
 
-	const object = new GodRaysEffect(null, null, null);
+	const lightSource = {
+		material: {}
+	};
+
+	const object = new GodRaysEffect(null, lightSource);
 	object.dispose();
 
 	t.truthy(object);

--- a/test/materials/DepthMaskMaterial.js
+++ b/test/materials/DepthMaskMaterial.js
@@ -1,0 +1,10 @@
+import test from "ava";
+import { DepthMaskMaterial } from "../../build/postprocessing.umd.js";
+
+test("can be created", t => {
+
+	const object = new DepthMaskMaterial();
+
+	t.truthy(object);
+
+});


### PR DESCRIPTION
### Notes

- Updated `three` to version `r102`.
   All passes now explicitly use `WebGLRenderer.setRenderTarget` and no longer pass render targets to `WebGLRenderer.render`. __This change breaks compatibility with older versions of three.__
- Improved performance of `GodRaysEffect` for more complex scenes.
- Changed constructor signatures of `ClearPass` and `RenderPass`.

See the release notes for more details about all changes.