### PR TITLE
Fullscreen Triangle

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ const clock = new Clock();
 
 This library provides an [EffectPass](https://vanruesc.github.io/postprocessing/public/docs/class/src/passes/EffectPass.js~EffectPass.html) which automatically organizes and merges any given combination of effects. This minimizes the amount of render operations and makes it possible to combine many effects without the performance penalties of traditional pass chaining. Additionally, every effect can choose its own [blend function](https://vanruesc.github.io/postprocessing/public/docs/variable/index.html#static-variable-BlendFunction).
 
+Furthermore, all fullscreen render operations use a [single triangle](https://michaldrobot.com/2014/04/01/gcn-execution-patterns-in-full-screen-passes/) that fills the screen. Compared to using a quad, this approach harmonizes with modern GPU rasterization patterns and eliminates unnecessary fragment calculations along the screen diagonal which is especially beneficial for GPGPU passes and effects that use complex fragment shaders.
+
 [Performance Test](http://vanruesc.github.io/postprocessing/public/demo/#performance)
 
 ## Included Effects

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -72,6 +72,7 @@ const demo = {
 		external: external,
 		plugins: [resolve(), commonjs(), glsl({
 			include: ["**/*.frag", "**/*.vert"],
+			compress: production,
 			sourceMap: false
 		})],
 		output: [{

--- a/src/effects/glsl/chromatic-aberration/shader.vert
+++ b/src/effects/glsl/chromatic-aberration/shader.vert
@@ -3,9 +3,9 @@ uniform vec2 offset;
 varying vec2 vUvR;
 varying vec2 vUvB;
 
-void mainSupport() {
+void mainSupport(const in vec2 uv) {
 
-	vUvR = vUv + offset;
-	vUvB = vUv - offset;
+	vUvR = uv + offset;
+	vUvB = uv - offset;
 
 }

--- a/src/effects/glsl/outline/shader.vert
+++ b/src/effects/glsl/outline/shader.vert
@@ -2,8 +2,8 @@ uniform float patternScale;
 
 varying vec2 vUvPattern;
 
-void mainSupport() {
+void mainSupport(const in vec2 uv) {
 
-	vUvPattern = vUv * vec2(aspect, 1.0) * patternScale;
+	vUvPattern = uv * vec2(aspect, 1.0) * patternScale;
 
 }

--- a/src/effects/glsl/smaa/shader.vert
+++ b/src/effects/glsl/smaa/shader.vert
@@ -1,9 +1,9 @@
 varying vec2 vOffset0;
 varying vec2 vOffset1;
 
-void mainSupport() {
+void mainSupport(const in vec2 uv) {
 
-	vOffset0 = vUv + texelSize * vec2(1.0, 0.0);
-	vOffset1 = vUv + texelSize * vec2(0.0, -1.0); // Changed sign in Y component.
+	vOffset0 = uv + texelSize * vec2(1.0, 0.0);
+	vOffset1 = uv + texelSize * vec2(0.0, -1.0); // Changed sign in Y component.
 
 }

--- a/src/effects/glsl/texture/shader.vert
+++ b/src/effects/glsl/texture/shader.vert
@@ -2,8 +2,8 @@ uniform float scale;
 
 varying vec2 vUv2;
 
-void mainSupport() {
+void mainSupport(const in vec2 uv) {
 
-	vUv2 = vUv * vec2(aspect, 1.0) * scale;
+	vUv2 = uv * vec2(aspect, 1.0) * scale;
 
 }

--- a/src/passes/EffectPass.js
+++ b/src/passes/EffectPass.js
@@ -119,8 +119,19 @@ function integrateEffect(prefix, effect, shaderParts, blendModes, defines, unifo
 
 		if(shaders.get("vertex") !== null && shaders.get("vertex").indexOf("mainSupport") >= 0) {
 
-			shaderParts.set(Section.VERTEX_MAIN_SUPPORT, shaderParts.get(Section.VERTEX_MAIN_SUPPORT) +
-				"\t" + prefix + "MainSupport();\n");
+			let string = "\t" + prefix + "MainSupport(";
+
+			// Check if the vertex shader expects uv coordinates.
+			if(shaders.get("vertex").indexOf("uv") >= 0) {
+
+				string += "vUv";
+
+			}
+
+			string += ");\n";
+
+			shaderParts.set(Section.VERTEX_MAIN_SUPPORT,
+				shaderParts.get(Section.VERTEX_MAIN_SUPPORT) + string);
 
 			varyings = varyings.concat(findSubstrings(varyingRegExp, shaders.get("vertex")));
 			names = names.concat(varyings).concat(findSubstrings(functionRegExp, shaders.get("vertex")));

--- a/src/passes/Pass.js
+++ b/src/passes/Pass.js
@@ -30,8 +30,10 @@ function getFullscreenTriangle() {
 	if(geometry === null) {
 
 		const vertices = new Float32Array([-1, -1, 0, 3, -1, 0, -1, 3, 0]);
+		const uvs = new Float32Array([0, 0, 2, 0, 0, 2]);
 		geometry = new BufferGeometry();
 		geometry.addAttribute("position", new BufferAttribute(vertices, 3));
+		geometry.addAttribute("uv", new BufferAttribute(uvs, 2));
 
 	}
 


### PR DESCRIPTION
- Replaced the fullscreen quad with a single triangle that is shared between fullscreen passes.
- Added an optional vertex shader function signature: `mainSupport(const in vec2 uv);`
- The `uv` attribute will likely be removed in a future release.
