### PR TITLE
SMAA update

### DIFF
--- a/src/effects/SMAAEffect.js
+++ b/src/effects/SMAAEffect.js
@@ -33,9 +33,10 @@ export class SMAAEffect extends Effect {
 	 *
 	 * @param {Image} searchImage - The SMAA search image. Preload this image using the {@link searchImageDataURL}.
 	 * @param {Image} areaImage - The SMAA area image. Preload this image using the {@link areaImageDataURL}.
+	 * @param {SMAAPreset} [preset=SMAAPreset.HIGH] - An SMAA quality preset.
 	 */
 
-	constructor(searchImage, areaImage) {
+	constructor(searchImage, areaImage, preset = SMAAPreset.HIGH) {
 
 		super("SMAAEffect", fragmentShader, {
 
@@ -136,6 +137,8 @@ export class SMAAEffect extends Effect {
 			return areaTexture;
 
 		})();
+
+		this.applyPreset(preset);
 
 	}
 

--- a/src/effects/SMAAEffect.js
+++ b/src/effects/SMAAEffect.js
@@ -117,7 +117,7 @@ export class SMAAEffect extends Effect {
 			searchTexture.format = RGBAFormat;
 			searchTexture.generateMipmaps = false;
 			searchTexture.needsUpdate = true;
-			searchTexture.flipY = false;
+			searchTexture.flipY = true;
 
 			return searchTexture;
 
@@ -126,7 +126,6 @@ export class SMAAEffect extends Effect {
 		this.weightsPass.getFullscreenMaterial().uniforms.areaTexture.value = (() => {
 
 			const areaTexture = new Texture(areaImage);
-
 			areaTexture.name = "SMAA.Area";
 			areaTexture.minFilter = LinearFilter;
 			areaTexture.format = RGBAFormat;
@@ -141,10 +140,35 @@ export class SMAAEffect extends Effect {
 	}
 
 	/**
+	 * The internal color edge detection material.
+	 *
+	 * @type {ColorEdgesMaterial}
+	 */
+
+	get colorEdgesMaterial() {
+
+		return this.colorEdgesPass.getFullscreenMaterial();
+
+	}
+
+	/**
+	 * The internal edge weights material.
+	 *
+	 * @type {SMAAWeightsMaterial}
+	 */
+
+	get weightsMaterial() {
+
+		return this.weightsPass.getFullscreenMaterial();
+
+	}
+
+	/**
 	 * Sets the edge detection sensitivity.
 	 *
 	 * See {@link ColorEdgesMaterial#setEdgeDetectionThreshold} for more details.
 	 *
+	 * @deprecated Use applyPreset or colorEdgesMaterial instead.
 	 * @param {Number} threshold - The edge detection sensitivity. Range: [0.05, 0.5].
 	 */
 
@@ -159,12 +183,62 @@ export class SMAAEffect extends Effect {
 	 *
 	 * See {@link SMAAWeightsMaterial#setOrthogonalSearchSteps} for more details.
 	 *
+	 * @deprecated Use applyPreset or weightsMaterial instead.
 	 * @param {Number} steps - The search steps. Range: [0, 112].
 	 */
 
 	setOrthogonalSearchSteps(steps) {
 
 		this.weightsPass.getFullscreenMaterial().setOrthogonalSearchSteps(steps);
+
+	}
+
+	/**
+	 * Applies the given quality preset.
+	 *
+	 * @param {SMAAPreset} preset - The preset.
+	 */
+
+	applyPreset(preset) {
+
+		const colorEdgesMaterial = this.colorEdgesMaterial;
+		const weightsMaterial = this.weightsMaterial;
+
+		switch(preset) {
+
+			case SMAAPreset.LOW:
+				colorEdgesMaterial.setEdgeDetectionThreshold(0.15);
+				weightsMaterial.setOrthogonalSearchSteps(4);
+				weightsMaterial.diagonalDetection = false;
+				weightsMaterial.cornerRounding = false;
+				break;
+
+			case SMAAPreset.MEDIUM:
+				colorEdgesMaterial.setEdgeDetectionThreshold(0.1);
+				weightsMaterial.setOrthogonalSearchSteps(8);
+				weightsMaterial.diagonalDetection = false;
+				weightsMaterial.cornerRounding = false;
+				break;
+
+			case SMAAPreset.HIGH:
+				colorEdgesMaterial.setEdgeDetectionThreshold(0.1);
+				weightsMaterial.setOrthogonalSearchSteps(16);
+				weightsMaterial.setDiagonalSearchSteps(8);
+				weightsMaterial.setCornerRounding(25);
+				weightsMaterial.diagonalDetection = true;
+				weightsMaterial.cornerRounding = true;
+				break;
+
+			case SMAAPreset.ULTRA:
+				colorEdgesMaterial.setEdgeDetectionThreshold(0.05);
+				weightsMaterial.setOrthogonalSearchSteps(32);
+				weightsMaterial.setDiagonalSearchSteps(16);
+				weightsMaterial.setCornerRounding(25);
+				weightsMaterial.diagonalDetection = true;
+				weightsMaterial.cornerRounding = true;
+				break;
+
+		}
 
 	}
 
@@ -193,12 +267,15 @@ export class SMAAEffect extends Effect {
 
 	setSize(width, height) {
 
+		const colorEdgesMaterial = this.colorEdgesPass.getFullscreenMaterial();
+		const weightsMaterial = this.weightsPass.getFullscreenMaterial();
+
 		this.renderTargetColorEdges.setSize(width, height);
 		this.renderTargetWeights.setSize(width, height);
 
-		this.colorEdgesPass.getFullscreenMaterial().uniforms.texelSize.value.copy(
-			this.weightsPass.getFullscreenMaterial().uniforms.texelSize.value.set(
-				1.0 / width, 1.0 / height));
+		weightsMaterial.uniforms.resolution.value.set(width, height);
+		weightsMaterial.uniforms.texelSize.value.set(1.0 / width, 1.0 / height);
+		colorEdgesMaterial.uniforms.texelSize.value.copy(weightsMaterial.uniforms.texelSize.value);
 
 	}
 
@@ -241,3 +318,22 @@ export class SMAAEffect extends Effect {
 	}
 
 }
+
+/**
+ * An enumeration of SMAA presets.
+ *
+ * @type {Object}
+ * @property {Number} LOW - Results in around 60% of the maximum quality.
+ * @property {Number} MEDIUM - Results in around 80% of the maximum quality.
+ * @property {Number} HIGH - Results in around 95% of the maximum quality.
+ * @property {Number} ULTRA - Results in around 99% of the maximum quality.
+ */
+
+export const SMAAPreset = {
+
+	LOW: 0,
+	MEDIUM: 1,
+	HIGH: 2,
+	ULTRA: 3
+
+};

--- a/src/effects/glsl/smaa/shader.vert
+++ b/src/effects/glsl/smaa/shader.vert
@@ -4,6 +4,6 @@ varying vec2 vOffset1;
 void mainSupport(const in vec2 uv) {
 
 	vOffset0 = uv + texelSize * vec2(1.0, 0.0);
-	vOffset1 = uv + texelSize * vec2(0.0, -1.0); // Changed sign in Y component.
+	vOffset1 = uv + texelSize * vec2(0.0, 1.0);
 
 }

--- a/src/effects/index.js
+++ b/src/effects/index.js
@@ -21,7 +21,7 @@ export { RealisticBokehEffect } from "./RealisticBokehEffect.js";
 export { ScanlineEffect } from "./ScanlineEffect.js";
 export { ShockWaveEffect } from "./ShockWaveEffect.js";
 export { SepiaEffect } from "./SepiaEffect.js";
-export { SMAAEffect } from "./SMAAEffect.js";
+export { SMAAEffect, SMAAPreset } from "./SMAAEffect.js";
 export { SSAOEffect } from "./SSAOEffect.js";
 export { TextureEffect } from "./TextureEffect.js";
 export { ToneMappingEffect } from "./ToneMappingEffect.js";

--- a/src/images/smaa/searchImageDataURL.js
+++ b/src/images/smaa/searchImageDataURL.js
@@ -1,2 +1,2 @@
-// Generated with SMAASearchImageData.generate().toCanvas().toDataURL(), not cropped, low dynamic range.
-export default "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAEIAAAAhCAAAAABIXyLAAAAAOElEQVRIx2NgGAWjYBSMglEwEICREYRgFBZBqDCSLA2MGPUIVQETE9iNUAqLR5gIeoQKRgwXjwAAGn4AtaFeYLEAAAAASUVORK5CYII";
+// Generated with SMAASearchImageData.generate().toCanvas().toDataURL(), cropped, high dynamic range.
+export default "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAEAAAAAQCAYAAACm53kpAAAAeElEQVRYR+2XSwqAMAxEJ168ePEqwRSKhIIiuHjJqiU0gWE+1CQdApcVAMUAuARaMGCX1MIL/Ow13++9lW2s3mW9MWvsnWc/2fvGygwPAN4E8QzAA4CXAB6AHjG4JTHYI1ey3pcx6FHnEfhLDOIBKAmUBK6/ANUDTlROXAHd9EC1AAAAAElFTkSuQmCC";

--- a/src/index.js
+++ b/src/index.js
@@ -32,6 +32,7 @@ export {
 	ShockWaveEffect,
 	SepiaEffect,
 	SMAAEffect,
+	SMAAPreset,
 	SSAOEffect,
 	TextureEffect,
 	ToneMappingEffect,

--- a/src/materials/ColorEdgesMaterial.js
+++ b/src/materials/ColorEdgesMaterial.js
@@ -25,6 +25,7 @@ export class ColorEdgesMaterial extends ShaderMaterial {
 
 			defines: {
 
+				LOCAL_CONTRAST_ADAPTATION_FACTOR: "2.0",
 				EDGE_THRESHOLD: "0.1"
 
 			},
@@ -47,6 +48,26 @@ export class ColorEdgesMaterial extends ShaderMaterial {
 	}
 
 	/**
+	 * Sets the local contrast adaptation factor.
+	 *
+	 * If there is a neighbor edge that has _factor_ times bigger contrast than
+	 * the current edge, the edge will be discarded.
+	 *
+	 * This allows to eliminate spurious crossing edges and is based on the fact
+	 * that if there is too much contrast in a direction, the perceptual contrast
+	 * in the other neighbors will be hidden.
+	 *
+	 * @param {Number} threshold - The local contrast adaptation factor. Default is 2.0.
+	 */
+
+	setLocalContrastAdaptationFactor(factor) {
+
+		this.defines.LOCAL_CONTRAST_ADAPTATION_FACTOR = factor.toFixed("2");
+		this.needsUpdate = true;
+
+	}
+
+	/**
 	 * Sets the edge detection sensitivity.
 	 *
 	 * A lower value results in more edges being detected at the expense of
@@ -55,13 +76,15 @@ export class ColorEdgesMaterial extends ShaderMaterial {
 	 * 0.1 is a reasonable value, and allows to catch most visible edges.
 	 * 0.05 is a rather overkill value, that allows to catch 'em all.
 	 *
-	 * If temporal supersampling is used, 0.2 could be a reasonable value,
-	 * as low contrast edges are properly filtered by just 2x.
+	 * If temporal supersampling is used, 0.2 could be a reasonable value, as low
+	 * contrast edges are properly filtered by just 2x.
 	 *
 	 * @param {Number} threshold - The edge detection sensitivity. Range: [0.05, 0.5].
 	 */
 
 	setEdgeDetectionThreshold(threshold) {
+
+		threshold = Math.min(Math.max(threshold, 0.05), 0.5);
 
 		this.defines.EDGE_THRESHOLD = threshold.toFixed("2");
 		this.needsUpdate = true;

--- a/src/materials/SMAAWeightsMaterial.js
+++ b/src/materials/SMAAWeightsMaterial.js
@@ -15,9 +15,10 @@ export class SMAAWeightsMaterial extends ShaderMaterial {
 	 * Constructs a new SMAA weights material.
 	 *
 	 * @param {Vector2} [texelSize] - The absolute screen texel size.
+	 * @param {Vector2} [resolution] - The resolution.
 	 */
 
-	constructor(texelSize = new Vector2()) {
+	constructor(texelSize = new Vector2(), resolution = new Vector2()) {
 
 		super({
 
@@ -26,11 +27,16 @@ export class SMAAWeightsMaterial extends ShaderMaterial {
 			defines: {
 
 				// Configurable settings:
-				MAX_SEARCH_STEPS_INT: "8",
-				MAX_SEARCH_STEPS_FLOAT: "8.0",
+				MAX_SEARCH_STEPS_INT: "16",
+				MAX_SEARCH_STEPS_FLOAT: "16.0",
+				MAX_SEARCH_STEPS_DIAG_INT: "8",
+				MAX_SEARCH_STEPS_DIAG_FLOAT: "8.0",
+				CORNER_ROUNDING: "25",
+				CORNER_ROUNDING_NORM: "0.25",
 
 				// Non-configurable settings:
 				AREATEX_MAX_DISTANCE: "16.0",
+				AREATEX_MAX_DISTANCE_DIAG: "20.0",
 				AREATEX_PIXEL_SIZE: "(1.0 / vec2(160.0, 560.0))",
 				AREATEX_SUBTEX_SIZE: "(1.0 / 7.0)",
 				SEARCHTEX_SIZE: "vec2(66.0, 33.0)",
@@ -43,7 +49,8 @@ export class SMAAWeightsMaterial extends ShaderMaterial {
 				inputBuffer: new Uniform(null),
 				areaTexture: new Uniform(null),
 				searchTexture: new Uniform(null),
-				texelSize: new Uniform(texelSize)
+				texelSize: new Uniform(texelSize),
+				resolution: new Uniform(resolution)
 
 			},
 
@@ -70,8 +77,100 @@ export class SMAAWeightsMaterial extends ShaderMaterial {
 
 	setOrthogonalSearchSteps(steps) {
 
+		steps = Math.min(Math.max(steps, 0), 112);
+
 		this.defines.MAX_SEARCH_STEPS_INT = steps.toFixed("0");
 		this.defines.MAX_SEARCH_STEPS_FLOAT = steps.toFixed("1");
+		this.needsUpdate = true;
+
+	}
+
+	/**
+	 * Specifies the maximum steps performed in the diagonal pattern searches, at
+	 * each side of the pixel. This search jumps one pixel at time.
+	 *
+	 * On high-end machines this search is cheap (between 0.8x and 0.9x slower for
+	 * 16 steps), but it can have a significant impact on older machines.
+	 *
+	 * @param {Number} steps - The search steps. Range: [0, 20].
+	 */
+
+	setDiagonalSearchSteps(steps) {
+
+		steps = Math.min(Math.max(steps, 0), 20);
+
+		this.defines.MAX_SEARCH_STEPS_DIAG_INT = steps.toFixed("0");
+		this.defines.MAX_SEARCH_STEPS_DIAG_FLOAT = steps.toFixed("1");
+		this.needsUpdate = true;
+
+	}
+
+	/**
+	 * Specifies how much sharp corners will be rounded.
+	 *
+	 * @param {Number} rounding - The corner rounding amount. Range: [0, 100].
+	 */
+
+	setCornerRounding(rounding) {
+
+		rounding = Math.min(Math.max(rounding, 0), 100);
+
+		this.defines.CORNER_ROUNDING = rounding.toFixed("4");
+		this.defines.CORNER_ROUNDING_NORM = (rounding / 100.0).toFixed("4");
+		this.needsUpdate = true;
+
+	}
+
+	/**
+	 * Indicates whether diagonal pattern detection is enabled.
+	 *
+	 * @type {Boolean}
+	 */
+
+	get diagonalDetection() {
+
+		return (this.defines.DISABLE_DIAG_DETECTION === undefined);
+
+	}
+
+	/**
+	 * Enables or disables diagonal pattern detection.
+	 *
+	 * @type {Boolean}
+	 */
+
+	set diagonalDetection(value) {
+
+		value ? (delete this.defines.DISABLE_DIAG_DETECTION) :
+			(this.defines.DISABLE_DIAG_DETECTION = "1");
+
+		this.needsUpdate = true;
+
+	}
+
+	/**
+	 * Indicates whether corner rounding is enabled.
+	 *
+	 * @type {Boolean}
+	 */
+
+	get cornerRounding() {
+
+		return (this.defines.DISABLE_CORNER_DETECTION === undefined);
+
+	}
+
+	/**
+	 * Enables or disables corner rounding.
+	 *
+	 * @type {Boolean}
+	 */
+
+	set cornerRounding(value) {
+
+		value ? (delete this.defines.DISABLE_CORNER_DETECTION) :
+			(this.defines.DISABLE_CORNER_DETECTION = "1");
+
 		this.needsUpdate = true;
 
 	}

--- a/src/materials/glsl/color-edges/shader.frag
+++ b/src/materials/glsl/color-edges/shader.frag
@@ -60,8 +60,8 @@ void main() {
 	maxDelta = max(max(maxDelta, delta.z), delta.w);
 
 	// Local contrast adaptation.
-	edges *= step(0.5 * maxDelta, delta.xy);
+	edges *= step(maxDelta, LOCAL_CONTRAST_ADAPTATION_FACTOR * delta.xy);
 
-	gl_FragColor = vec4(edges, 0.0, 0.0);
+	gl_FragColor = vec4(edges, 0.0, 1.0);
 
 }

--- a/src/materials/glsl/color-edges/shader.vert
+++ b/src/materials/glsl/color-edges/shader.vert
@@ -15,15 +15,15 @@ void main() {
 
 	// Left and top texel coordinates.
 	vUv0 = vUv + texelSize * vec2(-1.0, 0.0);
-	vUv1 = vUv + texelSize * vec2(0.0, 1.0);
+	vUv1 = vUv + texelSize * vec2(0.0, -1.0);
 
 	// Right and bottom texel coordinates.
 	vUv2 = vUv + texelSize * vec2(1.0, 0.0);
-	vUv3 = vUv + texelSize * vec2(0.0, -1.0);
+	vUv3 = vUv + texelSize * vec2(0.0, 1.0);
 
 	// Left-left and top-top texel coordinates.
 	vUv4 = vUv + texelSize * vec2(-2.0, 0.0);
-	vUv5 = vUv + texelSize * vec2(0.0, 2.0);
+	vUv5 = vUv + texelSize * vec2(0.0, -2.0);
 
 	gl_Position = vec4(position.xy, 1.0, 1.0);
 

--- a/src/materials/glsl/smaa-weights/shader.frag
+++ b/src/materials/glsl/smaa-weights/shader.frag
@@ -1,42 +1,281 @@
-#define sampleLevelZeroOffset(t, coord, offset) texture2D(t, coord + float(offset) * texelSize, 0.0)
+#define sampleLevelZeroOffset(t, coord, offset) texture2D(t, coord + offset * texelSize)
+
+#if __VERSION__ < 300
+
+	#define round(v) floor(v + 0.5)
+
+#endif
 
 uniform sampler2D inputBuffer;
 uniform sampler2D areaTexture;
 uniform sampler2D searchTexture;
 
 uniform vec2 texelSize;
+uniform vec2 resolution;
 
 varying vec2 vUv;
 varying vec4 vOffset[3];
 varying vec2 vPixCoord;
 
-#if __VERSION__ < 300
 
-	vec2 round(vec2 x) {
+/**
+ * Moves values to a target vector based on a given conditional vector.
+ */
 
-		return sign(x) * floor(abs(x) + 0.5);
+void movec(const in bvec2 c, inout vec2 variable, const in vec2 value) {
 
-	}
-
-#endif
-
-float searchLength(vec2 e, float bias, float scale) {
-
-	// Not required if searchTexture accesses are set to point.
-	// const vec2 SEARCH_TEX_PIXEL_SIZE = 1.0 / vec2(66.0, 33.0);
-	// e = vec2(bias, 0.0) + 0.5 * SEARCH_TEX_PIXEL_SIZE + e * vec2(scale, 1.0) * vec2(64.0, 32.0) * SEARCH_TEX_PIXEL_SIZE;
-
-	e.r = bias + e.r * scale;
-
-	return 255.0 * texture2D(searchTexture, e, 0.0).r;
+	if(c.x) { variable.x = value.x; }
+	if(c.y) { variable.y = value.y; }
 
 }
 
-float searchXLeft(vec2 texCoord, float end) {
+void movec(const in bvec4 c, inout vec4 variable, const in vec4 value) {
+
+	movec(c.xy, variable.xy, value.xy);
+	movec(c.zw, variable.zw, value.zw);
+
+}
+
+/**
+ * Allows to decode two binary values from a bilinear-filtered access.
+ *
+ * Bilinear access for fetching 'e' have a 0.25 offset, and we are interested
+ * in the R and G edges:
+ *
+ * +---G---+-------+
+ * |   x o R   x   |
+ * +-------+-------+
+ *
+ * Then, if one of these edge is enabled:
+ *  Red: (0.75 * X + 0.25 * 1) => 0.25 or 1.0
+ *  Green: (0.75 * 1 + 0.25 * X) => 0.75 or 1.0
+ *
+ * This function will unpack the values (mad + mul + round):
+ * wolframalpha.com: round(x * abs(5 * x - 5 * 0.75)) plot 0 to 1
+ */
+
+vec2 decodeDiagBilinearAccess(in vec2 e) {
+
+	e.r = e.r * abs(5.0 * e.r - 5.0 * 0.75);
+
+	return round(e);
+
+}
+
+vec4 decodeDiagBilinearAccess(in vec4 e) {
+
+	e.rb = e.rb * abs(5.0 * e.rb - 5.0 * 0.75);
+
+	return round(e);
+
+}
+
+/**
+ * Diagonal pattern searches.
+ */
+
+vec2 searchDiag1(const in vec2 texCoord, const in vec2 dir, out vec2 e) {
+
+	vec4 coord = vec4(texCoord, -1.0, 1.0);
+	vec3 t = vec3(texelSize, 1.0);
+
+	for(int i = 0; i < MAX_SEARCH_STEPS_INT; ++i) {
+
+		if(!(coord.z < float(MAX_SEARCH_STEPS_DIAG_INT - 1) && coord.w > 0.9)) {
+
+			break;
+
+		}
+
+		coord.xyz = t * vec3(dir, 1.0) + coord.xyz;
+		e = texture2D(inputBuffer, coord.xy).rg;
+		coord.w = dot(e, vec2(0.5));
+
+	}
+
+	return coord.zw;
+
+}
+
+vec2 searchDiag2(const in vec2 texCoord, const in vec2 dir, out vec2 e) {
+
+	vec4 coord = vec4(texCoord, -1.0, 1.0);
+	coord.x += 0.25 * texelSize.x; // See @SearchDiag2Optimization
+	vec3 t = vec3(texelSize, 1.0);
+
+	for(int i = 0; i < MAX_SEARCH_STEPS_INT; ++i) {
+
+		if(!(coord.z < float(MAX_SEARCH_STEPS_DIAG_INT - 1) && coord.w > 0.9)) {
+
+			break;
+
+		}
+
+		coord.xyz = t * vec3(dir, 1.0) + coord.xyz;
+
+		// @SearchDiag2Optimization
+		// Fetch both edges at once using bilinear filtering.
+		e = texture2D(inputBuffer, coord.xy).rg;
+		e = decodeDiagBilinearAccess(e);
+
+		// Non-optimized version:
+		// e.g = texture2D(inputBuffer, coord.xy).g;
+		// e.r = SMAASampleLevelZeroOffset(inputBuffer, coord.xy, vec2(1, 0)).r;
+
+		coord.w = dot(e, vec2(0.5));
+
+	}
+
+	return coord.zw;
+
+}
+
+/**
+ * Calculates the area corresponding to a certain diagonal distance and crossing
+ * edges 'e'.
+ */
+
+vec2 areaDiag(const in vec2 dist, const in vec2 e, const in float offset) {
+
+	vec2 texCoord = vec2(AREATEX_MAX_DISTANCE_DIAG, AREATEX_MAX_DISTANCE_DIAG) * e + dist;
+
+	// Apply a scale and bias for mapping to texel space.
+	texCoord = AREATEX_PIXEL_SIZE * texCoord + 0.5 * AREATEX_PIXEL_SIZE;
+
+	// Diagonal areas are on the second half of the texture.
+	texCoord.x += 0.5;
+
+	// Move to the proper place, according to the subpixel offset.
+	texCoord.y += AREATEX_SUBTEX_SIZE * offset;
+
+	return texture2D(areaTexture, texCoord).rg;
+
+}
+
+/**
+ * Searches for diagonal patterns and returns the corresponding weights.
+ */
+
+vec2 calculateDiagWeights(const in vec2 texCoord, const in vec2 e, const in vec4 subsampleIndices) {
+
+	vec2 weights = vec2(0.0);
+
+	// Search for the line ends.
+	vec4 d;
+	vec2 end;
+
+	if(e.r > 0.0) {
+
+		d.xz = searchDiag1(texCoord, vec2(-1.0,  1.0), end);
+		d.x += float(end.y > 0.9);
+
+	} else {
+
+		d.xz = vec2(0.0);
+
+	}
+
+	d.yw = searchDiag1(texCoord, vec2(1.0, -1.0), end);
+
+	if(d.x + d.y > 2.0) { // d.x + d.y + 1 > 3
+
+		// Fetch the crossing edges.
+		vec4 coords = vec4(-d.x + 0.25, d.x, d.y, -d.y - 0.25) * texelSize.xyxy + texCoord.xyxy;
+		vec4 c;
+		c.xy = sampleLevelZeroOffset(inputBuffer, coords.xy, vec2(-1, 0)).rg;
+		c.zw = sampleLevelZeroOffset(inputBuffer, coords.zw, vec2(1, 0)).rg;
+		c.yxwz = decodeDiagBilinearAccess(c.xyzw);
+
+		// Non-optimized version:
+		// vec4 coords = vec4(-d.x, d.x, d.y, -d.y) * texelSize.xyxy + texCoord.xyxy;
+		// vec4 c;
+		// c.x = sampleLevelZeroOffset(inputBuffer, coords.xy, vec2(-1, 0)).g;
+		// c.y = sampleLevelZeroOffset(inputBuffer, coords.xy, vec2(0, 0)).r;
+		// c.z = sampleLevelZeroOffset(inputBuffer, coords.zw, vec2(1, 0)).g;
+		// c.w = sampleLevelZeroOffset(inputBuffer, coords.zw, vec2(1, -1)).r;
+
+		// Merge crossing edges at each side into a single value.
+		vec2 cc = vec2(2.0) * c.xz + c.yw;
+
+		// Remove the crossing edge if no end of the line could be found.
+		movec(bvec2(step(0.9, d.zw)), cc, vec2(0.0));
+
+		// Fetch the areas for this line.
+		weights += areaDiag(d.xy, cc, subsampleIndices.z);
+
+	}
+
+	// Search for the line ends.
+	d.xz = searchDiag2(texCoord, vec2(-1.0, -1.0), end);
+
+	if(sampleLevelZeroOffset(inputBuffer, texCoord, vec2(1, 0)).r > 0.0) {
+
+		d.yw = searchDiag2(texCoord, vec2(1.0), end);
+		d.y += float(end.y > 0.9);
+
+	} else {
+
+		d.yw = vec2(0.0);
+
+	}
+
+	if(d.x + d.y > 2.0) { // d.x + d.y + 1 > 3
+
+		// Fetch the crossing edges.
+		vec4 coords = vec4(-d.x, -d.x, d.y, d.y) * texelSize.xyxy + texCoord.xyxy;
+		vec4 c;
+		c.x = sampleLevelZeroOffset(inputBuffer, coords.xy, vec2(-1, 0)).g;
+		c.y = sampleLevelZeroOffset(inputBuffer, coords.xy, vec2(0, -1)).r;
+		c.zw = sampleLevelZeroOffset(inputBuffer, coords.zw, vec2(1, 0)).gr;
+		vec2 cc = vec2(2.0) * c.xz + c.yw;
+
+		// Remove the crossing edge if no end of the line could be found.
+		movec(bvec2(step(0.9, d.zw)), cc, vec2(0.0));
+
+		// Fetch the areas for this line.
+		weights += areaDiag(d.xy, cc, subsampleIndices.w).gr;
+
+	}
+
+	return weights;
+
+}
+
+/**
+ * Determines how much length should be added in the last step of the searches.
+ *
+ * Takes the bilinearly interpolated edge (see @PSEUDO_GATHER4), and adds 0, 1
+ * or 2 depending on which edges and crossing edges are active.
+ */
+
+float searchLength(const in vec2 e, const in float offset) {
+
+	/* The texture is flipped vertically, with left and right cases taking half
+	of the space horizontally. */
+	vec2 scale = SEARCHTEX_SIZE * vec2(0.5, -1.0);
+	vec2 bias = SEARCHTEX_SIZE * vec2(offset, 1.0);
+
+	// Scale and bias to access texel centers.
+	scale += vec2(-1.0, 1.0);
+	bias += vec2(0.5, -0.5);
+
+	// Convert from pixel coordinates to texcoords.
+	scale *= 1.0 / SEARCHTEX_PACKED_SIZE;
+	bias *= 1.0 / SEARCHTEX_PACKED_SIZE;
+
+	return texture2D(searchTexture, scale * e + bias).r;
+
+}
+
+/**
+ * Horizontal search for the second pass.
+ */
+
+float searchXLeft(in vec2 texCoord, const in float end) {
 
 	/* @PSEUDO_GATHER4
 	This texCoord has been offset by (-0.25, -0.125) in the vertex shader to
-	sample between edge, thus fetching four edges in a row.
+	sample between edges, thus fetching four edges in a row.
 	Sampling with different offsets in each direction allows to disambiguate
 	which edges are active from the four fetched ones. */
 
@@ -44,105 +283,169 @@ float searchXLeft(vec2 texCoord, float end) {
 
 	for(int i = 0; i < MAX_SEARCH_STEPS_INT; ++i) {
 
-		e = texture2D(inputBuffer, texCoord, 0.0).rg;
-		texCoord -= vec2(2.0, 0.0) * texelSize;
+		if(!(texCoord.x > end && e.g > 0.8281 && e.r == 0.0)) {
 
-		if(!(texCoord.x > end && e.g > 0.8281 && e.r == 0.0)) { break; }
+			break;
 
-	}
+		}
 
-	// Correct the previously applied offset (-0.25, -0.125).
-	texCoord.x += 0.25 * texelSize.x;
-
-	// The searches are biased by 1, so adjust the coords accordingly.
-	texCoord.x += texelSize.x;
-
-	// Disambiguate the length added by the last step.
-	texCoord.x += 2.0 * texelSize.x; // Undo last step.
-	texCoord.x -= texelSize.x * searchLength(e, 0.0, 0.5);
-
-	return texCoord.x;
-
-}
-
-float searchXRight(vec2 texCoord, float end) {
-
-	vec2 e = vec2(0.0, 1.0);
-
-	for(int i = 0; i < MAX_SEARCH_STEPS_INT; ++i) {
-
-		e = texture2D(inputBuffer, texCoord, 0.0).rg;
-		texCoord += vec2(2.0, 0.0) * texelSize;
-
-		if(!(texCoord.x < end && e.g > 0.8281 && e.r == 0.0)) { break; }
+		e = texture2D(inputBuffer, texCoord).rg;
+		texCoord = vec2(-2.0, 0.0) * texelSize + texCoord;
 
 	}
 
-	texCoord.x -= 0.25 * texelSize.x;
-	texCoord.x -= texelSize.x;
-	texCoord.x -= 2.0 * texelSize.x;
-	texCoord.x += texelSize.x * searchLength(e, 0.5, 0.5);
+  float offset = -(255.0 / 127.0) * searchLength(e, 0.0) + 3.25;
 
-	return texCoord.x;
+  return texelSize.x * offset + texCoord.x;
 
-}
-
-float searchYUp(vec2 texCoord, float end) {
-
-	vec2 e = vec2(1.0, 0.0);
-
-	for(int i = 0; i < MAX_SEARCH_STEPS_INT; ++i) {
-
-		e = texture2D(inputBuffer, texCoord, 0.0).rg;
-		texCoord += vec2(0.0, 2.0) * texelSize; // Changed sign.
-
-		if(!(texCoord.y > end && e.r > 0.8281 && e.g == 0.0)) { break; }
-
-	}
-
-	texCoord.y -= 0.25 * texelSize.y; // Changed sign.
-	texCoord.y -= texelSize.y; // Changed sign.
-	texCoord.y -= 2.0 * texelSize.y; // Changed sign.
-	texCoord.y += texelSize.y * searchLength(e.gr, 0.0, 0.5); // Changed sign.
-
-	return texCoord.y;
+  // Non-optimized version:
+  // Correct the previous (-0.25, -0.125) offset.
+  // texCoord.x += 0.25 * texelSize.x;
+  // The searches are biased by 1, so adjust the coords accordingly.
+  // texCoord.x += texelSize.x;
+  // Disambiguate the length added by the last step.
+  // texCoord.x += 2.0 * texelSize.x; // Undo last step.
+  // texCoord.x -= texelSize.x * (255.0 / 127.0) * searchLength(e, 0.0);
+  // return texelSize.x * offset + texCoord.x);
 
 }
 
-float searchYDown(vec2 texCoord, float end) {
+float searchXRight(vec2 texCoord, const in float end) {
 
-	vec2 e = vec2(1.0, 0.0);
+  vec2 e = vec2(0.0, 1.0);
 
-	for(int i = 0; i < MAX_SEARCH_STEPS_INT; ++i ) {
+  for(int i = 0; i < MAX_SEARCH_STEPS_INT; ++i) {
 
-		e = texture2D(inputBuffer, texCoord, 0.0).rg;
-		texCoord -= vec2(0.0, 2.0) * texelSize; // Changed sign.
+		if(!(texCoord.x < end && e.g > 0.8281 && e.r == 0.0)) {
 
-		if(!(texCoord.y < end && e.r > 0.8281 && e.g == 0.0)) { break; }
+			break;
 
-	}
+		}
 
-	texCoord.y += 0.25 * texelSize.y; // Changed sign.
-	texCoord.y += texelSize.y; // Changed sign.
-	texCoord.y += 2.0 * texelSize.y; // Changed sign.
-	texCoord.y -= texelSize.y * searchLength(e.gr, 0.5, 0.5); // Changed sign.
+    e = texture2D(inputBuffer, texCoord).rg;
+    texCoord = vec2(2.0, 0.0) * texelSize.xy + texCoord;
 
-	return texCoord.y;
+  }
+
+  float offset = -(255.0 / 127.0) * searchLength(e, 0.5) + 3.25;
+
+  return -texelSize.x * offset + texCoord.x;
 
 }
 
-vec2 area(vec2 dist, float e1, float e2, float offset) {
+/**
+ * Vertical search for the second pass.
+ */
 
-	// Rounding prevents precision errors of bilinear filtering.
-	vec2 texCoord = AREATEX_MAX_DISTANCE * round(4.0 * vec2(e1, e2)) + dist;
+float searchYUp(vec2 texCoord, const in float end) {
 
-	// Scale and bias for texel space translation.
-	texCoord = AREATEX_PIXEL_SIZE * texCoord + (0.5 * AREATEX_PIXEL_SIZE);
+  vec2 e = vec2(1.0, 0.0);
 
-	// Move to proper place, according to the subpixel offset.
-	texCoord.y += AREATEX_SUBTEX_SIZE * offset;
+  for(int i = 0; i < MAX_SEARCH_STEPS_INT; ++i) {
 
-	return texture2D(areaTexture, texCoord, 0.0).rg;
+		if(!(texCoord.y > end && e.r > 0.8281 && e.g == 0.0)) {
+
+			break;
+
+		}
+
+    e = texture2D(inputBuffer, texCoord).rg;
+    texCoord = -vec2(0.0, 2.0) * texelSize.xy + texCoord;
+
+  }
+
+  float offset = -(255.0 / 127.0) * searchLength(e.gr, 0.0) + 3.25;
+
+  return texelSize.y * offset + texCoord.y;
+
+}
+
+float searchYDown(vec2 texCoord, const in float end) {
+
+  vec2 e = vec2(1.0, 0.0);
+
+  for(int i = 0; i < MAX_SEARCH_STEPS_INT; i++) {
+
+		if(!(texCoord.y < end && e.r > 0.8281 && e.g == 0.0)) {
+
+			break;
+
+		}
+
+    e = texture2D(inputBuffer, texCoord).rg;
+    texCoord = vec2(0.0, 2.0) * texelSize.xy + texCoord;
+
+  }
+
+  float offset = -(255.0 / 127.0) * searchLength(e.gr, 0.5) + 3.25;
+
+  return -texelSize.y * offset + texCoord.y;
+
+}
+
+/**
+ * Determines the areas at each side of the current edge.
+ */
+
+vec2 area(const in vec2 dist, const in float e1, const in float e2, const in float offset) {
+
+  // Rounding prevents precision errors of bilinear filtering.
+  vec2 texCoord = vec2(AREATEX_MAX_DISTANCE) * round(4.0 * vec2(e1, e2)) + dist;
+
+  // Apply a scale and bias for mapping to texel space.
+  texCoord = AREATEX_PIXEL_SIZE * texCoord + 0.5 * AREATEX_PIXEL_SIZE;
+
+  // Move to the proper place, according to the subpixel offset.
+  texCoord.y = AREATEX_SUBTEX_SIZE * offset + texCoord.y;
+
+  return texture2D(areaTexture, texCoord).rg;
+
+}
+
+/**
+ * Corner detection.
+ */
+
+void detectHorizontalCornerPattern(inout vec2 weights, const in vec4 texCoord, const in vec2 d) {
+
+  #if !defined(DISABLE_CORNER_DETECTION)
+
+		vec2 leftRight = step(d.xy, d.yx);
+		vec2 rounding = (1.0 - CORNER_ROUNDING_NORM) * leftRight;
+
+		// Reduce blending for pixels in the center of a line.
+		rounding /= leftRight.x + leftRight.y;
+
+		vec2 factor = vec2(1.0);
+		factor.x -= rounding.x * sampleLevelZeroOffset(inputBuffer, texCoord.xy, vec2(0, 1)).r;
+		factor.x -= rounding.y * sampleLevelZeroOffset(inputBuffer, texCoord.zw, vec2(1, 1)).r;
+		factor.y -= rounding.x * sampleLevelZeroOffset(inputBuffer, texCoord.xy, vec2(0, -2)).r;
+		factor.y -= rounding.y * sampleLevelZeroOffset(inputBuffer, texCoord.zw, vec2(1, -2)).r;
+
+		weights *= saturate(factor);
+
+  #endif
+
+}
+
+void detectVerticalCornerPattern(inout vec2 weights, const in vec4 texCoord, const in vec2 d) {
+
+  #if !defined(DISABLE_CORNER_DETECTION)
+
+		vec2 leftRight = step(d.xy, d.yx);
+		vec2 rounding = (1.0 - CORNER_ROUNDING_NORM) * leftRight;
+
+		rounding /= leftRight.x + leftRight.y;
+
+		vec2 factor = vec2(1.0);
+		factor.x -= rounding.x * sampleLevelZeroOffset(inputBuffer, texCoord.xy, vec2(1, 0)).g;
+		factor.x -= rounding.y * sampleLevelZeroOffset(inputBuffer, texCoord.zw, vec2(1, 1)).g;
+		factor.y -= rounding.x * sampleLevelZeroOffset(inputBuffer, texCoord.xy, vec2(-2, 0)).g;
+		factor.y -= rounding.y * sampleLevelZeroOffset(inputBuffer, texCoord.zw, vec2(-2, 1)).g;
+
+		weights *= saturate(factor);
+
+  #endif
 
 }
 
@@ -155,10 +458,22 @@ void main() {
 	if(e.g > 0.0) {
 
 		// Edge at north.
+
+    #if !defined(DISABLE_DIAG_DETECTION)
+
+			/* Diagonals have both north and west edges, so searching for them in one of
+			the boundaries is enough. */
+			weights.rg = calculateDiagWeights(vUv, e, subsampleIndices);
+
+			// Skip horizontal/vertical processing if there is a diagonal.
+			if(weights.r == -weights.g) { // weights.r + weights.g == 0.0
+
+    #endif
+
 		vec2 d;
 
 		// Find the distance to the left.
-		vec2 coords;
+		vec3 coords;
 		coords.x = searchXLeft(vOffset[0].xy, vOffset[2].x);
 		coords.y = vOffset[1].y; // vOffset[1].y = vUv.y - 0.25 * texelSize.y (@CROSSING_OFFSET)
 		d.x = coords.x;
@@ -166,58 +481,76 @@ void main() {
 		/* Now fetch the left crossing edges, two at a time using bilinear
 		filtering. Sampling at -0.25 (see @CROSSING_OFFSET) enables to discern what
 		value each edge has. */
-		float e1 = texture2D(inputBuffer, coords, 0.0).r;
+		float e1 = texture2D(inputBuffer, coords.xy).r;
 
 		// Find the distance to the right.
-		coords.x = searchXRight(vOffset[0].zw, vOffset[2].y);
-		d.y = coords.x;
+		coords.z = searchXRight(vOffset[0].zw, vOffset[2].y);
+		d.y = coords.z;
 
 		/* Translate distances to pixel units for better interleave arithmetic and
 		memory accesses. */
-		d = d / texelSize.x - vPixCoord.x;
+		d = round(resolution.xx * d + -vPixCoord.xx);
 
 		// The area texture is compressed quadratically.
 		vec2 sqrtD = sqrt(abs(d));
 
 		// Fetch the right crossing edges.
-		coords.y -= texelSize.y; // WebGL port note: Added.
-		float e2 = sampleLevelZeroOffset(inputBuffer, coords, ivec2(1, 0)).r;
+		float e2 = sampleLevelZeroOffset(inputBuffer, coords.zy, vec2(1, 0)).r;
 
-		// Pattern recognised, now get the actual area.
+		// Pattern recognized, now get the actual area.
 		weights.rg = area(sqrtD, e1, e2, subsampleIndices.y);
+
+    // Fix corners.
+    coords.y = vUv.y;
+    detectHorizontalCornerPattern(weights.rg, coords.xyzy, d);
+
+    #if !defined(DISABLE_DIAG_DETECTION)
+
+			} else {
+
+				// Skip vertical processing.
+				e.r = 0.0;
+
+			}
+
+    #endif
 
 	}
 
 	if(e.r > 0.0) {
 
 		// Edge at west.
+
 		vec2 d;
 
 		// Find the distance to the top.
-		vec2 coords;
+		vec3 coords;
 		coords.y = searchYUp(vOffset[1].xy, vOffset[2].z);
 		coords.x = vOffset[0].x; // vOffset[1].x = vUv.x - 0.25 * texelSize.x;
 		d.x = coords.y;
 
 		// Fetch the top crossing edges.
-		float e1 = texture2D(inputBuffer, coords, 0.0).g;
+		float e1 = texture2D(inputBuffer, coords.xy).g;
 
 		// Find the distance to the bottom.
-		coords.y = searchYDown(vOffset[1].zw, vOffset[2].w);
-		d.y = coords.y;
+		coords.z = searchYDown(vOffset[1].zw, vOffset[2].w);
+		d.y = coords.z;
 
-		// Distances in pixel units.
-		d = d / texelSize.y - vPixCoord.y;
+		// Translate distances into pixel units.
+		d = round(resolution.yy * d - vPixCoord.yy);
 
 		// The area texture is compressed quadratically.
 		vec2 sqrtD = sqrt(abs(d));
 
 		// Fetch the bottom crossing edges.
-		coords.y -= texelSize.y; // WebGL port note: Added.
-		float e2 = sampleLevelZeroOffset(inputBuffer, coords, ivec2(0, 1)).g;
+		float e2 = sampleLevelZeroOffset(inputBuffer, coords.xz, vec2(0, 1)).g;
 
 		// Get the area for this direction.
 		weights.ba = area(sqrtD, e1, e2, subsampleIndices.x);
+
+    // Fix corners.
+    coords.x = vUv.x;
+    detectVerticalCornerPattern(weights.ba, coords.xyxz, d);
 
 	}
 

--- a/src/materials/glsl/smaa-weights/shader.vert
+++ b/src/materials/glsl/smaa-weights/shader.vert
@@ -1,4 +1,5 @@
 uniform vec2 texelSize;
+uniform vec2 resolution;
 
 varying vec2 vUv;
 varying vec4 vOffset[3];
@@ -7,14 +8,15 @@ varying vec2 vPixCoord;
 void main() {
 
 	vUv = position.xy * 0.5 + 0.5;
-	vPixCoord = vUv / texelSize;
+	vPixCoord = vUv * resolution;
 
 	// Offsets for the searches (see @PSEUDO_GATHER4).
-	vOffset[0] = vUv.xyxy + texelSize.xyxy * vec4(-0.25, 0.125, 1.25, 0.125); // Changed sign in Y and W components.
-	vOffset[1] = vUv.xyxy + texelSize.xyxy * vec4(-0.125, 0.25, -0.125, -1.25); //Changed sign in Y and W components.
+	vOffset[0] = vUv.xyxy + texelSize.xyxy * vec4(-0.25, -0.125, 1.25, -0.125);
+	vOffset[1] = vUv.xyxy + texelSize.xyxy * vec4(-0.125, -0.25, -0.125, 1.25);
 
 	// This indicates the ends of the loops.
-	vOffset[2] = vec4(vOffset[0].xz, vOffset[1].yw) + vec4(-2.0, 2.0, -2.0, 2.0) * texelSize.xxyy * MAX_SEARCH_STEPS_FLOAT;
+	vOffset[2] = vec4(vOffset[0].xz, vOffset[1].yw) +
+		vec4(-2.0, 2.0, -2.0, 2.0) * texelSize.xxyy * MAX_SEARCH_STEPS_FLOAT;
 
 	gl_Position = vec4(position.xy, 1.0, 1.0);
 


### PR DESCRIPTION
Updated all SMAA shaders to match the [official code](https://github.com/iryoku/smaa/blob/master/SMAA.hlsl) more closely. Also used https://github.com/dmnsgn/glsl-smaa as an additional reference.

- Added `SMAAPreset` with `LOW`, `MEDIUM`, `HIGH` and `ULTRA` constants.
- This change adds _diagonal pattern detection_ and _corner rounding_ features to SMAA.
  - Both features will be enabled with the `HIGH` and `ULTRA` presets.
- The gamma correction code in the SMAA blend shader has been removed.

#### Preset Comparison
| Medium | Ultra |
|----------|-------|
| ![medium](https://user-images.githubusercontent.com/9214917/58752585-c4f55100-84b1-11e9-8c5a-9b97f65a7001.png) | ![ultra](https://user-images.githubusercontent.com/9214917/58752629-c410ef00-84b2-11e9-8c91-aea51ad7e660.png) |
