### PR TITLE
Ignore undefined keys in Pass dispose function

### DIFF
--- a/src/passes/Pass.js
+++ b/src/passes/Pass.js
@@ -302,7 +302,7 @@ export class Pass {
 
 		for(const key of Object.keys(this)) {
 
-			if(this[key] !== null && typeof this[key].dispose === "function") {
+			if(this[key] && this[key] !== null && typeof this[key].dispose === "function") {
 
 				/** @ignore */
 				this[key].dispose();


### PR DESCRIPTION
version: 6.5.1
browser: Chrome 75.0.3770.100
operating system: MacOS
graphics card: MacBook Pro 2018?

I am using this package with the react-three-fiber package. Here is my Effect Component:

````
const Effects = React.memo(() => {
    const { gl, scene, camera, size } = useThree();
    const composer = useRef();

    useEffect(() => void composer.current.setSize(size.width, size.height), [size.width, size.height]);
    useRender(() => composer.current.render(), true);

    const effect = useMemo(() => new PixelationEffect(100.0));
    return (
        <effectComposer ref={composer} args={[gl]}>
            <renderPass attachArray="passes" args={[scene, camera]} />
            <effectPass attachArray="passes" args={[camera, effect]} renderToScreen={true} />
        </effectComposer>
    );
});
````

In order for this to work, I need to make the fix in Pass.js file as per this PR. I am not sure if this is correct, or if I am simply doing something wrong. But here goes, a suggestion, that might be useful.

When using the library with react-three-fiber, the parent key is undefined
and the script will then fail. Here we check if the key exists, then we explicitly
check if it is null, I am not sure that null check is stil necessary?