### PR TITLE
Ignore parent keys in Pass dispose function

### DIFF
--- a/src/passes/Pass.js
+++ b/src/passes/Pass.js
@@ -302,7 +302,7 @@ export class Pass {
 
 		for(const key of Object.keys(this)) {
 
-			if(this[key] !== null && typeof this[key].dispose === "function") {
+			if(this[key] !== 'parent' && this[key] !== null && typeof this[key].dispose === "function") {
 
 				/** @ignore */
 				this[key].dispose();


### PR DESCRIPTION
Reopened as new PR, since I force pushed and was unable to reopen the other one (#138)
version: 6.5.1
browser: Chrome 75.0.3770.100
operating system: MacOS
graphics card: MacBook Pro 2018?

I am using this package with the react-three-fiber package. Here is my Effect Component:
````
const Effects = React.memo(() => {
    const { gl, scene, camera, size } = useThree();
    const composer = useRef();

    useEffect(() => void composer.current.setSize(size.width, size.height), [size.width, size.height]);
    useRender(() => composer.current.render(), true);

    const effect = useMemo(() => new PixelationEffect(100.0));
    return (
        <effectComposer ref={composer} args={[gl]}>
            <renderPass attachArray="passes" args={[scene, camera]} />
            <effectPass attachArray="passes" args={[camera, effect]} renderToScreen={true} />
        </effectComposer>
    );
});
````
In order for this to work, I need to make the fix in Pass.js file as per this PR. I am not sure if this is correct, or if I am simply doing something wrong. But here goes, a suggestion, that might be useful.

When using the library with react-three-fiber, the parent key is undefined
and the script will then fail. Here we check if the key exists, then we explicitly
check if it is null, I am not sure that null check is stil necessary?

The screen  is rendered, but I am getting this error below, and once I resize and trigger the composer.current.setSize I get a WSOD.

````
Uncaught TypeError: Cannot read property 'dispose' of undefined
    at EffectPass.dispose (postprocessing.esm.js:1420)
    at EffectPass.dispose (postprocessing.esm.js:3199)
    at index.js:291
    at unstable_runWithPriority (scheduler.development.js:255)
    at removeChild (index.js:284)
    at switchInstance (index.js:302)
    at commitUpdate (index.js:359)
    at commitWork (react-reconciler.development.js:9944)
    at commitAllHostEffects (react-reconciler.development.js:10663)
    at HTMLUnknownElement.callCallback (react-reconciler.development.js:2234)
    at Object.invokeGuardedCallbackDev (react-reconciler.development.js:2284)
    at invokeGuardedCallback (react-reconciler.development.js:2337)
    at commitRoot (react-reconciler.development.js:10896)
    at react-reconciler.development.js:12401
    at Object.unstable_runWithPriority (scheduler.development.js:255)
    at completeRoot (react-reconciler.development.js:12400)
    at performWorkOnRoot (react-reconciler.development.js:12329)
    at performWork (react-reconciler.development.js:12237)
    at performSyncWork (react-reconciler.development.js:12211)
    at requestWork (react-reconciler.development.js:12080)
    at commitPassiveEffects (react-reconciler.development.js:10778)
    at wrapped (scheduler-tracing.development.js:207)
    at flushFirstCallback (scheduler.development.js:107)
    at flushWork (scheduler.development.js:219)
    at MessagePort.push../node_modules/react-three-fiber/node_modules/scheduler/cjs/scheduler.development.js.channel.port1.onmessage (scheduler.development.js:611)
````