### PR TITLE
SMAA Image Loader

### DIFF
--- a/demo/src/demos/BloomDemo.js
+++ b/demo/src/demos/BloomDemo.js
@@ -22,7 +22,8 @@ import {
 	EffectPass,
 	KernelSize,
 	SelectiveBloomEffect,
-	SMAAEffect
+	SMAAEffect,
+	SMAAImageLoader
 } from "../../../src";
 
 /**
@@ -213,6 +214,7 @@ export class BloomDemo extends PostProcessingDemo {
 		const assets = this.assets;
 		const loadingManager = this.loadingManager;
 		const cubeTextureLoader = new CubeTextureLoader(loadingManager);
+		const smaaImageLoader = new SMAAImageLoader(loadingManager);
 
 		const path = "textures/skies/space2/";
 		const format = ".jpg";
@@ -235,7 +237,12 @@ export class BloomDemo extends PostProcessingDemo {
 
 				});
 
-				this.loadSMAAImages();
+				smaaImageLoader.load(([search, area]) => {
+
+					assets.set("smaa-search", search);
+					assets.set("smaa-area", area);
+
+				});
 
 			} else {
 

--- a/demo/src/demos/BlurDemo.js
+++ b/demo/src/demos/BlurDemo.js
@@ -19,6 +19,7 @@ import {
 	KernelSize,
 	SavePass,
 	SMAAEffect,
+	SMAAImageLoader,
 	TextureEffect
 } from "../../../src";
 
@@ -87,6 +88,7 @@ export class BlurDemo extends PostProcessingDemo {
 		const assets = this.assets;
 		const loadingManager = this.loadingManager;
 		const cubeTextureLoader = new CubeTextureLoader(loadingManager);
+		const smaaImageLoader = new SMAAImageLoader(loadingManager);
 
 		const path = "textures/skies/sunset/";
 		const format = ".png";
@@ -109,7 +111,12 @@ export class BlurDemo extends PostProcessingDemo {
 
 				});
 
-				this.loadSMAAImages();
+				smaaImageLoader.load(([search, area]) => {
+
+					assets.set("smaa-search", search);
+					assets.set("smaa-area", area);
+
+				});
 
 			} else {
 

--- a/demo/src/demos/BokehDemo.js
+++ b/demo/src/demos/BokehDemo.js
@@ -17,6 +17,7 @@ import {
 	DepthEffect,
 	EffectPass,
 	SMAAEffect,
+	SMAAImageLoader,
 	VignetteEffect
 } from "../../../src";
 
@@ -76,6 +77,7 @@ export class BokehDemo extends PostProcessingDemo {
 		const assets = this.assets;
 		const loadingManager = this.loadingManager;
 		const cubeTextureLoader = new CubeTextureLoader(loadingManager);
+		const smaaImageLoader = new SMAAImageLoader(loadingManager);
 
 		const path = "textures/skies/space3/";
 		const format = ".jpg";
@@ -98,7 +100,12 @@ export class BokehDemo extends PostProcessingDemo {
 
 				});
 
-				this.loadSMAAImages();
+				smaaImageLoader.load(([search, area]) => {
+
+					assets.set("smaa-search", search);
+					assets.set("smaa-area", area);
+
+				});
 
 			} else {
 

--- a/demo/src/demos/ColorDepthDemo.js
+++ b/demo/src/demos/ColorDepthDemo.js
@@ -6,6 +6,7 @@ import {
 	BlendFunction,
 	EffectPass,
 	SMAAEffect,
+	SMAAImageLoader,
 	ColorDepthEffect
 } from "../../../src";
 
@@ -56,6 +57,7 @@ export class ColorDepthDemo extends PostProcessingDemo {
 		const assets = this.assets;
 		const loadingManager = this.loadingManager;
 		const cubeTextureLoader = new CubeTextureLoader(loadingManager);
+		const smaaImageLoader = new SMAAImageLoader(loadingManager);
 
 		const path = "textures/skies/space3/";
 		const format = ".jpg";
@@ -78,7 +80,12 @@ export class ColorDepthDemo extends PostProcessingDemo {
 
 				});
 
-				this.loadSMAAImages();
+				smaaImageLoader.load(([search, area]) => {
+
+					assets.set("smaa-search", search);
+					assets.set("smaa-area", area);
+
+				});
 
 			} else {
 

--- a/demo/src/demos/ColorGradingDemo.js
+++ b/demo/src/demos/ColorGradingDemo.js
@@ -10,7 +10,8 @@ import {
 	GammaCorrectionEffect,
 	HueSaturationEffect,
 	SepiaEffect,
-	SMAAEffect
+	SMAAEffect,
+	SMAAImageLoader
 } from "../../../src";
 
 /**
@@ -96,6 +97,7 @@ export class ColorGradingDemo extends PostProcessingDemo {
 		const assets = this.assets;
 		const loadingManager = this.loadingManager;
 		const cubeTextureLoader = new CubeTextureLoader(loadingManager);
+		const smaaImageLoader = new SMAAImageLoader(loadingManager);
 
 		const path = "textures/skies/sunset/";
 		const format = ".png";
@@ -118,7 +120,12 @@ export class ColorGradingDemo extends PostProcessingDemo {
 
 				});
 
-				this.loadSMAAImages();
+				smaaImageLoader.load(([search, area]) => {
+
+					assets.set("smaa-search", search);
+					assets.set("smaa-area", area);
+
+				});
 
 			} else {
 

--- a/demo/src/demos/GlitchDemo.js
+++ b/demo/src/demos/GlitchDemo.js
@@ -20,7 +20,8 @@ import {
 	GlitchMode,
 	GlitchEffect,
 	NoiseEffect,
-	SMAAEffect
+	SMAAEffect,
+	SMAAImageLoader
 } from "../../../src";
 
 /**
@@ -80,6 +81,7 @@ export class GlitchDemo extends PostProcessingDemo {
 		const loadingManager = this.loadingManager;
 		const textureLoader = new TextureLoader(loadingManager);
 		const cubeTextureLoader = new CubeTextureLoader(loadingManager);
+		const smaaImageLoader = new SMAAImageLoader(loadingManager);
 
 		const path = "textures/skies/space4/";
 		const format = ".jpg";
@@ -108,7 +110,12 @@ export class GlitchDemo extends PostProcessingDemo {
 
 				});
 
-				this.loadSMAAImages();
+				smaaImageLoader.load(([search, area]) => {
+
+					assets.set("smaa-search", search);
+					assets.set("smaa-area", area);
+
+				});
 
 			} else {
 

--- a/demo/src/demos/GodRaysDemo.js
+++ b/demo/src/demos/GodRaysDemo.js
@@ -19,7 +19,8 @@ import {
 	EffectPass,
 	GodRaysEffect,
 	KernelSize,
-	SMAAEffect
+	SMAAEffect,
+	SMAAImageLoader
 } from "../../../src";
 
 /**
@@ -86,8 +87,9 @@ export class GodRaysDemo extends PostProcessingDemo {
 
 		const assets = this.assets;
 		const loadingManager = this.loadingManager;
-		const cubeTextureLoader = new CubeTextureLoader(loadingManager);
 		const modelLoader = new GLTFLoader(loadingManager);
+		const cubeTextureLoader = new CubeTextureLoader(loadingManager);
+		const smaaImageLoader = new SMAAImageLoader(loadingManager);
 
 		const path = "textures/skies/starry/";
 		const format = ".png";
@@ -120,7 +122,12 @@ export class GodRaysDemo extends PostProcessingDemo {
 
 				});
 
-				this.loadSMAAImages();
+				smaaImageLoader.load(([search, area]) => {
+
+					assets.set("smaa-search", search);
+					assets.set("smaa-area", area);
+
+				});
 
 			} else {
 

--- a/demo/src/demos/OutlineDemo.js
+++ b/demo/src/demos/OutlineDemo.js
@@ -22,7 +22,8 @@ import {
 	EffectPass,
 	OutlineEffect,
 	KernelSize,
-	SMAAEffect
+	SMAAEffect,
+	SMAAImageLoader
 } from "../../../src";
 
 /**
@@ -187,6 +188,7 @@ export class OutlineDemo extends PostProcessingDemo {
 		const loadingManager = this.loadingManager;
 		const textureLoader = new TextureLoader(loadingManager);
 		const cubeTextureLoader = new CubeTextureLoader(loadingManager);
+		const smaaImageLoader = new SMAAImageLoader(loadingManager);
 
 		const path = "textures/skies/sunset/";
 		const format = ".png";
@@ -215,7 +217,12 @@ export class OutlineDemo extends PostProcessingDemo {
 
 				});
 
-				this.loadSMAAImages();
+				smaaImageLoader.load(([search, area]) => {
+
+					assets.set("smaa-search", search);
+					assets.set("smaa-area", area);
+
+				});
 
 			} else {
 

--- a/demo/src/demos/PerformanceDemo.js
+++ b/demo/src/demos/PerformanceDemo.js
@@ -34,6 +34,7 @@ import {
 	SepiaEffect,
 	ScanlineEffect,
 	SMAAEffect,
+	SMAAImageLoader,
 	TextureEffect,
 	VignetteEffect
 } from "../../../src";
@@ -155,8 +156,9 @@ export class PerformanceDemo extends PostProcessingDemo {
 
 		const assets = this.assets;
 		const loadingManager = this.loadingManager;
-		const cubeTextureLoader = new CubeTextureLoader(loadingManager);
 		const textureLoader = new TextureLoader(loadingManager);
+		const cubeTextureLoader = new CubeTextureLoader(loadingManager);
+		const smaaImageLoader = new SMAAImageLoader(loadingManager);
 
 		const path = "textures/skies/space5/";
 		const format = ".jpg";
@@ -186,7 +188,12 @@ export class PerformanceDemo extends PostProcessingDemo {
 
 				});
 
-				this.loadSMAAImages();
+				smaaImageLoader.load(([search, area]) => {
+
+					assets.set("smaa-search", search);
+					assets.set("smaa-area", area);
+
+				});
 
 			} else {
 

--- a/demo/src/demos/PixelationDemo.js
+++ b/demo/src/demos/PixelationDemo.js
@@ -19,7 +19,8 @@ import {
 	EffectPass,
 	MaskPass,
 	PixelationEffect,
-	SMAAEffect
+	SMAAEffect,
+	SMAAImageLoader
 } from "../../../src";
 
 /**
@@ -87,6 +88,7 @@ export class PixelationDemo extends PostProcessingDemo {
 		const assets = this.assets;
 		const loadingManager = this.loadingManager;
 		const cubeTextureLoader = new CubeTextureLoader(loadingManager);
+		const smaaImageLoader = new SMAAImageLoader(loadingManager);
 
 		const path = "textures/skies/space/";
 		const format = ".jpg";
@@ -109,7 +111,12 @@ export class PixelationDemo extends PostProcessingDemo {
 
 				});
 
-				this.loadSMAAImages();
+				smaaImageLoader.load(([search, area]) => {
+
+					assets.set("smaa-search", search);
+					assets.set("smaa-area", area);
+
+				});
 
 			} else {
 

--- a/demo/src/demos/PostProcessingDemo.js
+++ b/demo/src/demos/PostProcessingDemo.js
@@ -1,5 +1,5 @@
 import { Demo } from "three-demo";
-import { RenderPass, SMAAEffect } from "../../../src";
+import { RenderPass } from "../../../src";
 
 /**
  * A post processing demo base class.
@@ -35,44 +35,6 @@ export class PostProcessingDemo extends Demo {
 
 		this.renderPass = new RenderPass(this.scene, null);
 		this.renderPass.renderToScreen = true;
-
-	}
-
-	/**
-	 * Loads the SMAA images.
-	 *
-	 * @protected
-	 */
-
-	loadSMAAImages() {
-
-		const assets = this.assets;
-		const loadingManager = this.loadingManager;
-
-		const searchImage = new Image();
-		const areaImage = new Image();
-
-		searchImage.addEventListener("load", function() {
-
-			assets.set("smaa-search", this);
-			loadingManager.itemEnd("smaa-search");
-
-		});
-
-		areaImage.addEventListener("load", function() {
-
-			assets.set("smaa-area", this);
-			loadingManager.itemEnd("smaa-area");
-
-		});
-
-		// Register the new image assets.
-		loadingManager.itemStart("smaa-search");
-		loadingManager.itemStart("smaa-area");
-
-		// Load the images asynchronously.
-		searchImage.src = SMAAEffect.searchImageDataURL;
-		areaImage.src = SMAAEffect.areaImageDataURL;
 
 	}
 

--- a/demo/src/demos/RealisticBokehDemo.js
+++ b/demo/src/demos/RealisticBokehDemo.js
@@ -16,6 +16,7 @@ import {
 	RealisticBokehEffect,
 	EffectPass,
 	SMAAEffect,
+	SMAAImageLoader,
 	VignetteEffect
 } from "../../../src";
 
@@ -66,6 +67,7 @@ export class RealisticBokehDemo extends PostProcessingDemo {
 		const assets = this.assets;
 		const loadingManager = this.loadingManager;
 		const cubeTextureLoader = new CubeTextureLoader(loadingManager);
+		const smaaImageLoader = new SMAAImageLoader(loadingManager);
 
 		const path = "textures/skies/space3/";
 		const format = ".jpg";
@@ -88,7 +90,12 @@ export class RealisticBokehDemo extends PostProcessingDemo {
 
 				});
 
-				this.loadSMAAImages();
+				smaaImageLoader.load(([search, area]) => {
+
+					assets.set("smaa-search", search);
+					assets.set("smaa-area", area);
+
+				});
 
 			} else {
 

--- a/demo/src/demos/SMAADemo.js
+++ b/demo/src/demos/SMAADemo.js
@@ -20,6 +20,7 @@ import { PostProcessingDemo } from "./PostProcessingDemo.js";
 import {
 	BlendFunction,
 	EffectPass,
+	SMAAImageLoader,
 	SMAAEffect,
 	SMAAPreset,
 	TextureEffect
@@ -147,6 +148,7 @@ export class SMAADemo extends PostProcessingDemo {
 		const loadingManager = this.loadingManager;
 		const textureLoader = new TextureLoader(loadingManager);
 		const cubeTextureLoader = new CubeTextureLoader(loadingManager);
+		const smaaImageLoader = new SMAAImageLoader(loadingManager);
 
 		const path = "textures/skies/sunset/";
 		const format = ".png";
@@ -177,7 +179,12 @@ export class SMAADemo extends PostProcessingDemo {
 
 				});
 
-				this.loadSMAAImages();
+				smaaImageLoader.load((smaa) => {
+
+					assets.set("smaa-search", smaa.search);
+					assets.set("smaa-area", smaa.area);
+
+				});
 
 			} else {
 

--- a/demo/src/demos/SMAADemo.js
+++ b/demo/src/demos/SMAADemo.js
@@ -20,8 +20,8 @@ import { PostProcessingDemo } from "./PostProcessingDemo.js";
 import {
 	BlendFunction,
 	EffectPass,
-	SMAAImageLoader,
 	SMAAEffect,
+	SMAAImageLoader,
 	SMAAPreset,
 	TextureEffect
 } from "../../../src";
@@ -179,10 +179,10 @@ export class SMAADemo extends PostProcessingDemo {
 
 				});
 
-				smaaImageLoader.load((smaa) => {
+				smaaImageLoader.load(([search, area]) => {
 
-					assets.set("smaa-search", smaa.search);
-					assets.set("smaa-area", smaa.area);
+					assets.set("smaa-search", search);
+					assets.set("smaa-area", area);
 
 				});
 

--- a/demo/src/demos/SSAODemo.js
+++ b/demo/src/demos/SSAODemo.js
@@ -15,7 +15,8 @@ import {
 	EffectPass,
 	NormalPass,
 	SSAOEffect,
-	SMAAEffect
+	SMAAEffect,
+	SMAAImageLoader
 } from "../../../src";
 
 /**
@@ -92,6 +93,7 @@ export class SSAODemo extends PostProcessingDemo {
 		const assets = this.assets;
 		const loadingManager = this.loadingManager;
 		const cubeTextureLoader = new CubeTextureLoader(loadingManager);
+		const smaaImageLoader = new SMAAImageLoader(loadingManager);
 
 		const path = "textures/skies/starry/";
 		const format = ".png";
@@ -114,7 +116,12 @@ export class SSAODemo extends PostProcessingDemo {
 
 				});
 
-				this.loadSMAAImages();
+				smaaImageLoader.load(([search, area]) => {
+
+					assets.set("smaa-search", search);
+					assets.set("smaa-area", area);
+
+				});
 
 			} else {
 

--- a/demo/src/demos/ShockWaveDemo.js
+++ b/demo/src/demos/ShockWaveDemo.js
@@ -10,7 +10,13 @@ import {
 
 import { DeltaControls } from "delta-controls";
 import { PostProcessingDemo } from "./PostProcessingDemo.js";
-import { EffectPass, ShockWaveEffect, SMAAEffect } from "../../../src";
+
+import {
+	EffectPass,
+	ShockWaveEffect,
+	SMAAEffect,
+	SMAAImageLoader
+} from "../../../src";
 
 /**
  * A shock wave demo setup.
@@ -50,6 +56,7 @@ export class ShockWaveDemo extends PostProcessingDemo {
 		const assets = this.assets;
 		const loadingManager = this.loadingManager;
 		const cubeTextureLoader = new CubeTextureLoader(loadingManager);
+		const smaaImageLoader = new SMAAImageLoader(loadingManager);
 
 		const path = "textures/skies/space3/";
 		const format = ".jpg";
@@ -72,7 +79,12 @@ export class ShockWaveDemo extends PostProcessingDemo {
 
 				});
 
-				this.loadSMAAImages();
+				smaaImageLoader.load(([search, area]) => {
+
+					assets.set("smaa-search", search);
+					assets.set("smaa-area", area);
+
+				});
 
 			} else {
 

--- a/demo/src/demos/TextureDemo.js
+++ b/demo/src/demos/TextureDemo.js
@@ -12,6 +12,7 @@ import {
 	BlendFunction,
 	EffectPass,
 	SMAAEffect,
+	SMAAImageLoader,
 	TextureEffect
 } from "../../../src";
 
@@ -63,6 +64,7 @@ export class TextureDemo extends PostProcessingDemo {
 		const loadingManager = this.loadingManager;
 		const textureLoader = new TextureLoader(loadingManager);
 		const cubeTextureLoader = new CubeTextureLoader(loadingManager);
+		const smaaImageLoader = new SMAAImageLoader(loadingManager);
 
 		const path = "textures/skies/sunset/";
 		const format = ".png";
@@ -92,7 +94,12 @@ export class TextureDemo extends PostProcessingDemo {
 
 				});
 
-				this.loadSMAAImages();
+				smaaImageLoader.load(([search, area]) => {
+
+					assets.set("smaa-search", search);
+					assets.set("smaa-area", area);
+
+				});
 
 			} else {
 

--- a/demo/src/demos/ToneMappingDemo.js
+++ b/demo/src/demos/ToneMappingDemo.js
@@ -17,7 +17,8 @@ import {
 	BlendFunction,
 	ToneMappingEffect,
 	EffectPass,
-	SMAAEffect
+	SMAAEffect,
+	SMAAImageLoader
 } from "../../../src";
 
 /**
@@ -77,6 +78,7 @@ export class ToneMappingDemo extends PostProcessingDemo {
 		const loadingManager = this.loadingManager;
 		const textureLoader = new TextureLoader(loadingManager);
 		const cubeTextureLoader = new CubeTextureLoader(loadingManager);
+		const smaaImageLoader = new SMAAImageLoader(loadingManager);
 
 		const path = "textures/skies/sunset/";
 		const format = ".png";
@@ -106,7 +108,12 @@ export class ToneMappingDemo extends PostProcessingDemo {
 
 				});
 
-				this.loadSMAAImages();
+				smaaImageLoader.load(([search, area]) => {
+
+					assets.set("smaa-search", search);
+					assets.set("smaa-area", area);
+
+				});
 
 			} else {
 

--- a/demo/src/demos/VignetteDemo.js
+++ b/demo/src/demos/VignetteDemo.js
@@ -16,6 +16,7 @@ import {
 	BlendFunction,
 	EffectPass,
 	SMAAEffect,
+	SMAAImageLoader,
 	VignetteEffect
 } from "../../../src";
 
@@ -75,6 +76,7 @@ export class VignetteDemo extends PostProcessingDemo {
 		const assets = this.assets;
 		const loadingManager = this.loadingManager;
 		const cubeTextureLoader = new CubeTextureLoader(loadingManager);
+		const smaaImageLoader = new SMAAImageLoader(loadingManager);
 
 		const path = "textures/skies/space/";
 		const format = ".jpg";
@@ -97,7 +99,12 @@ export class VignetteDemo extends PostProcessingDemo {
 
 				});
 
-				this.loadSMAAImages();
+				smaaImageLoader.load(([search, area]) => {
+
+					assets.set("smaa-search", search);
+					assets.set("smaa-area", area);
+
+				});
 
 			} else {
 

--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
 		"rollup": "1.x.x",
 		"rollup-plugin-babel": "4.x.x",
 		"rollup-plugin-glsl": "1.x.x",
+		"rollup-plugin-string": "3.x.x",
 		"rollup-plugin-terser": "5.x.x",
 		"synthetic-event": "1.x.x",
 		"three": "0.112.x",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,6 +19,7 @@ devDependencies:
   rollup: 1.29.0
   rollup-plugin-babel: 4.3.3_@babel+core@7.8.3+rollup@1.29.0
   rollup-plugin-glsl: 1.3.0
+  rollup-plugin-string: 3.0.0
   rollup-plugin-terser: 5.2.0_rollup@1.29.0
   synthetic-event: 1.0.0
   three: 0.112.1
@@ -3722,7 +3723,7 @@ packages:
       integrity: sha1-h+IBAJ6/3m9G3FdXMFpwr3HjFiQ=
   /magic-string/0.25.6:
     dependencies:
-      sourcemap-codec: 1.4.7
+      sourcemap-codec: 1.4.8
     dev: true
     resolution:
       integrity: sha512-3a5LOMSGoCTH5rbqobC2HuDNRtE2glHZ8J7pK+QZYppyWA36yuNpsX994rIY2nCuyP7CZYy7lQq/X2jygiZ89g==
@@ -4716,6 +4717,12 @@ packages:
     dev: true
     resolution:
       integrity: sha512-iddxdkQmuo6Hfk5JuT2ntVe8D5hvZ+r3uyPotjIkF2JYNOEdamEWCnieoLGCcxU16pWFoV/tmu74qkeR5Q/ChQ==
+  /rollup-plugin-string/3.0.0:
+    dependencies:
+      rollup-pluginutils: 2.8.2
+    dev: true
+    resolution:
+      integrity: sha512-vqyzgn9QefAgeKi+Y4A7jETeIAU1zQmS6VotH6bzm/zmUQEnYkpIGRaOBPY41oiWYV4JyBoGAaBjYMYuv+6wVw==
   /rollup-plugin-terser/5.2.0_rollup@1.29.0:
     dependencies:
       '@babel/code-frame': 7.8.3
@@ -4895,10 +4902,10 @@ packages:
       node: '>=0.10.0'
     resolution:
       integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
-  /sourcemap-codec/1.4.7:
+  /sourcemap-codec/1.4.8:
     dev: true
     resolution:
-      integrity: sha512-RuN23NzhAOuUtaivhcrjXx1OPXsFeH9m5sI373/U7+tGLKihjUyboZAzOadytMjnqHp1f45RGk1IzDKCpDpSYA==
+      integrity: sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==
   /spawn-command/0.0.2-1:
     dev: true
     resolution:
@@ -5630,6 +5637,7 @@ specifiers:
   rollup: 1.29.0
   rollup-plugin-babel: 4.3.3
   rollup-plugin-glsl: 1.3.0
+  rollup-plugin-string: 3.0.0
   rollup-plugin-terser: 5.2.0
   synthetic-event: 1.0.0
   three: 0.112.1

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -24,9 +24,7 @@ const globals = Object.assign({}, ...external.map((value) => ({
 const worker = {
 
 	input: "src/images/smaa/utils/worker.js",
-	plugins: [resolve()].concat(production ? [minify({
-		comments: false
-	}), babel()] : []),
+	plugins: [resolve()].concat(production ? [terser(), babel()] : []),
 	output: {
 		file: "src/images/smaa/utils/worker.tmp",
 		format: "iife"

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -2,6 +2,7 @@ import commonjs from "@rollup/plugin-commonjs";
 import resolve from "@rollup/plugin-node-resolve";
 import babel from "rollup-plugin-babel";
 import glsl from "rollup-plugin-glsl";
+import { string } from "rollup-plugin-string";
 import { terser } from "rollup-plugin-terser";
 
 const pkg = require("./package.json");
@@ -20,6 +21,19 @@ const globals = Object.assign({}, ...external.map((value) => ({
 	[value]: value.replace(/-/g, "").toUpperCase()
 })));
 
+const worker = {
+
+	input: "src/images/smaa/utils/worker.js",
+	plugins: [resolve()].concat(production ? [minify({
+		comments: false
+	}), babel()] : []),
+	output: {
+		file: "src/images/smaa/utils/worker.tmp",
+		format: "iife"
+	}
+
+}
+
 const lib = {
 
 	module: {
@@ -29,6 +43,8 @@ const lib = {
 			include: ["**/*.frag", "**/*.vert"],
 			compress: production,
 			sourceMap: false
+		}), string({
+			include: ["**/*.tmp"]
 		})],
 		output: [{
 			file: pkg.module,
@@ -83,6 +99,8 @@ const demo = {
 			include: ["**/*.frag", "**/*.vert"],
 			compress: production,
 			sourceMap: false
+		}), string({
+			include: ["**/*.tmp"]
 		})],
 		output: [{
 			file: "public/demo/index.js",
@@ -102,6 +120,8 @@ const demo = {
 			include: ["**/*.frag", "**/*.vert"],
 			compress: false,
 			sourceMap: false
+		}), string({
+			include: ["**/*.tmp"]
 		})],
 		output: [{
 			file: "public/demo/index.js",
@@ -123,7 +143,7 @@ const demo = {
 
 };
 
-export default (production ? [
+export default [worker].concat(production ? [
 	lib.module, lib.main, lib.min,
 	demo.module, demo.main, demo.min
 ] : [demo.main]);

--- a/src/effects/SMAAEffect.js
+++ b/src/effects/SMAAEffect.js
@@ -31,8 +31,8 @@ export class SMAAEffect extends Effect {
 	/**
 	 * Constructs a new SMAA effect.
 	 *
-	 * @param {Image} searchImage - The SMAA search image. Preload this image using the {@link searchImageDataURL}.
-	 * @param {Image} areaImage - The SMAA area image. Preload this image using the {@link areaImageDataURL}.
+	 * @param {Image} searchImage - The SMAA search image. Preload this image using the {@link SMAAImageLoader}.
+	 * @param {Image} areaImage - The SMAA area image. Preload this image using the {@link SMAAImageLoader}.
 	 * @param {SMAAPreset} [preset=SMAAPreset.HIGH] - An SMAA quality preset.
 	 */
 
@@ -289,6 +289,7 @@ export class SMAAEffect extends Effect {
 	 * the area image to create an {@link SMAAEffect}.
 	 *
 	 * @type {String}
+	 * @deprecated Use SMAAImageLoader instead.
 	 * @example
 	 * const searchImage = new Image();
 	 * searchImage.addEventListener("load", progress);
@@ -308,6 +309,7 @@ export class SMAAEffect extends Effect {
 	 * the search image to create an {@link SMAAEffect}.
 	 *
 	 * @type {String}
+	 * @deprecated Use SMAAImageLoader instead.
 	 * @example
 	 * const areaImage = new Image();
 	 * areaImage.addEventListener("load", progress);

--- a/src/images/RawImageData.js
+++ b/src/images/RawImageData.js
@@ -5,36 +5,16 @@
  * @param {Number} width - The image width.
  * @param {Number} height - The image height.
  * @param {Uint8ClampedArray} data - The image data.
- * @param {Number} channels - The color channels used for a single pixel.
  * @return {Canvas} The canvas.
  */
 
-function createCanvas(width, height, data, channels) {
+function createCanvas(width, height, data) {
 
 	const canvas = document.createElementNS("http://www.w3.org/1999/xhtml", "canvas");
 	const context = canvas.getContext("2d");
 
 	const imageData = context.createImageData(width, height);
-	const target = imageData.data;
-
-	let x, y;
-	let i, j;
-
-	for(y = 0; y < height; ++y) {
-
-		for(x = 0; x < width; ++x) {
-
-			i = (y * width + x) * 4;
-			j = (y * width + x) * channels;
-
-			target[i] = (channels > 0) ? data[j] : 0;
-			target[i + 1] = (channels > 1) ? data[j + 1] : 0;
-			target[i + 2] = (channels > 2) ? data[j + 2] : 0;
-			target[i + 3] = (channels > 3) ? data[j + 3] : 255;
-
-		}
-
-	}
+	imageData.data.set(data);
 
 	canvas.width = width;
 	canvas.height = height;
@@ -57,10 +37,9 @@ export class RawImageData {
 	 * @param {Number} [width=0] - The width of the image.
 	 * @param {Number} [height=0] - The height of the image.
 	 * @param {Uint8ClampedArray} [data=null] - The image data.
-	 * @param {Number} [channels=4] - The amount of color channels used per pixel. Range [1, 4].
 	 */
 
-	constructor(width = 0, height = 0, data = null, channels = 4) {
+	constructor(width = 0, height = 0, data = null) {
 
 		/**
 		 * The width of the image.
@@ -86,14 +65,6 @@ export class RawImageData {
 
 		this.data = data;
 
-		/**
-		 * The amount of color channels used per pixel. Range [1, 4].
-		 *
-		 * @type {Number}
-		 */
-
-		this.channels = channels;
-
 	}
 
 	/**
@@ -107,9 +78,21 @@ export class RawImageData {
 		return (typeof document === "undefined") ? null : createCanvas(
 			this.width,
 			this.height,
-			this.data,
-			this.channels
+			this.data
 		);
+
+	}
+
+	/**
+	 * Creates a new image data container.
+	 *
+	 * @param {Object} data - Raw image data.
+	 * @return {RawImageData} The image data.
+	 */
+
+	static from(data) {
+
+		return new RawImageData(data.width, data.height, data.data);
 
 	}
 

--- a/src/images/index.js
+++ b/src/images/index.js
@@ -1,4 +1,4 @@
+export { SMAAImageLoader } from "./smaa/utils/SMAAImageLoader.js";
 export { SMAAAreaImageData } from "./smaa/utils/SMAAAreaImageData.js";
 export { SMAASearchImageData } from "./smaa/utils/SMAASearchImageData.js";
-
 export { RawImageData } from "./RawImageData.js";

--- a/src/images/smaa/utils/SMAAAreaImageData.js
+++ b/src/images/smaa/utils/SMAAAreaImageData.js
@@ -1215,7 +1215,7 @@ function assemble(base, patterns, edges, size, orthogonal, target) {
 					edge[1] * size + base.y + y
 				);
 
-				c = (p.y * dstWidth + p.x) * 2;
+				c = (p.y * dstWidth + p.x) * 4;
 
 				/* The texture coordinates of orthogonal patterns are compressed
 				quadratically to reach longer distances for a given texture size. */
@@ -1224,6 +1224,8 @@ function assemble(base, patterns, edges, size, orthogonal, target) {
 
 				dstData[c] = srcData[d];
 				dstData[c + 1] = srcData[d + 1];
+				dstData[c + 2] = 0;
+				dstData[c + 3] = 255;
 
 			}
 
@@ -1256,8 +1258,8 @@ export class SMAAAreaImageData {
 		const width = 2 * 5 * ORTHOGONAL_SIZE;
 		const height = orthogonalSubsamplingOffsets.length * 5 * ORTHOGONAL_SIZE;
 
-		const data = new Uint8ClampedArray(width * height * 2);
-		const result = new RawImageData(width, height, data, 2);
+		const data = new Uint8ClampedArray(width * height * 4);
+		const result = new RawImageData(width, height, data);
 
 		const orthogonalPatternSize = Math.pow(ORTHOGONAL_SIZE - 1, 2) + 1;
 		const diagonalPatternSize = DIAGONAL_SIZE;

--- a/src/images/smaa/utils/SMAAAreaImageData.js
+++ b/src/images/smaa/utils/SMAAAreaImageData.js
@@ -1,5 +1,79 @@
-import { Box2, Vector2 } from "three";
 import { RawImageData } from "../../RawImageData.js";
+
+/**
+ * A 2D vector.
+ *
+ * @private
+ */
+
+class Vector2 {
+
+	/**
+	 * Constructs a new vector.
+	 *
+	 * @param {Number} [x=0] - The initial x value.
+	 * @param {Number} [y=0] - The initial y value.
+	 */
+
+	constructor(x = 0, y = 0) {
+
+		this.x = x;
+		this.y = y;
+
+	}
+
+	/**
+	 * Sets the components of this vector.
+	 *
+	 * @param {Number} x - The new x value.
+	 * @param {Number} y - The new y value.
+	 * @return {Vector2} This vector.
+	 */
+
+	set(x, y) {
+
+		this.x = x;
+		this.y = y;
+
+		return this;
+
+	}
+
+	/**
+	 * Checks if the given vector equals this vector.
+	 *
+	 * @param {Vector2} v - A vector.
+	 * @return {Boolean} Whether this vector equals the given one.
+	 */
+
+	equals(v) {
+
+		return (this === v || (this.x === v.x && this.y === v.y));
+
+	}
+
+}
+
+/**
+ * A 2D box.
+ *
+ * @private
+ */
+
+class Box2 {
+
+	/**
+	 * Constructs a new box.
+	 */
+
+	constructor() {
+
+		this.min = new Vector2();
+		this.max = new Vector2();
+
+	}
+
+}
 
 /**
  * A box.
@@ -64,13 +138,7 @@ const SMOOTH_MAX_DISTANCE = 32;
  */
 
 const orthogonalSubsamplingOffsets = new Float32Array([
-	0.0,
-	-0.25,
-	0.25,
-	-0.125,
-	0.125,
-	-0.375,
-	0.375
+	0.0, -0.25, 0.25, -0.125, 0.125, -0.375, 0.375
 ]);
 
 /**
@@ -387,7 +455,7 @@ function calculateOrthogonalAreaForPattern(pattern, left, right, offset, result)
 
 			smoothArea(d, a);
 
-			result.addVectors(a1, a2);
+			result.set(a1.x + a2.x, a1.y + a2.y);
 
 			break;
 
@@ -443,9 +511,10 @@ function calculateOrthogonalAreaForPattern(pattern, left, right, offset, result)
 
 				calculateOrthogonalArea(p1.set(0.0, o1), p2.set(d, o2), left, a1);
 				calculateOrthogonalArea(p1.set(0.0, o1), p2.set(d / 2.0, 0.0), left, a2);
-				a2.add(calculateOrthogonalArea(p1.set(d / 2.0, 0.0), p2.set(d, o2), left, result));
+				calculateOrthogonalArea(p1.set(d / 2.0, 0.0), p2.set(d, o2), left, result);
+				a2.set(a2.x + result.x, a2.y + result.y);
 
-				result.addVectors(a1, a2).divideScalar(2.0);
+				result.set((a1.x + a2.x) / 2.0, (a1.y + a2.y) / 2.0);
 
 			} else {
 
@@ -501,9 +570,10 @@ function calculateOrthogonalAreaForPattern(pattern, left, right, offset, result)
 
 				calculateOrthogonalArea(p1.set(0.0, o2), p2.set(d, o1), left, a1);
 				calculateOrthogonalArea(p1.set(0.0, o2), p2.set(d / 2.0, 0.0), left, a2);
-				a2.add(calculateOrthogonalArea(p1.set(d / 2.0, 0.0), p2.set(d, o1), left, result));
+				calculateOrthogonalArea(p1.set(d / 2.0, 0.0), p2.set(d, o1), left, result);
+				a2.set(a2.x + result.x, a2.y + result.y);
 
-				result.addVectors(a1, a2).divideScalar(2.0);
+				result.set((a1.x + a2.x) / 2.0, (a1.y + a2.y) / 2.0);
 
 			} else {
 
@@ -552,7 +622,7 @@ function calculateOrthogonalAreaForPattern(pattern, left, right, offset, result)
 
 			smoothArea(d, a);
 
-			result.addVectors(a1, a2);
+			result.set(a1.x + a2.x, a1.y + a2.y);
 
 			break;
 
@@ -618,18 +688,15 @@ function isInsideArea(p1, p2, x, y) {
 
 	let result = p1.equals(p2);
 
-	let xm, ym;
-	let a, b, c;
-
 	if(!result) {
 
-		xm = (p1.x + p2.x) / 2.0;
-		ym = (p1.y + p2.y) / 2.0;
+		let xm = (p1.x + p2.x) / 2.0;
+		let ym = (p1.y + p2.y) / 2.0;
 
-		a = p2.y - p1.y;
-		b = p1.x - p2.x;
+		let a = p2.y - p1.y;
+		let b = p1.x - p2.x;
 
-		c = a * (x - xm) + b * (y - ym);
+		let c = a * (x - xm) + b * (y - ym);
 
 		result = (c > 0.0);
 
@@ -746,7 +813,7 @@ function calculateDiagonalAreaForPattern(pattern, left, right, offset, result) {
 	 * Unlike orthogonal patterns, the "null" pattern (one without crossing edges)
 	 * must be filtered, and the ends of both the "null" and L patterns are not
 	 * known: L and U patterns have different endings, and the adjacent pattern is
-	 * unknown. Therefore, a blend of both possibilites is computed.
+	 * unknown. Therefore, a blend of both possibilities is computed.
 	 */
 
 	switch(pattern) {
@@ -767,7 +834,7 @@ function calculateDiagonalAreaForPattern(pattern, left, right, offset, result) {
 			calculateDiagonalArea(pattern, p1.set(1.0, 0.0), p2.set(1.0 + d, 0.0 + d), left, offset, a2);
 
 			// Blend both possibilities together.
-			result.addVectors(a1, a2).divideScalar(2.0);
+			result.set((a1.x + a2.x) / 2.0, (a1.y + a2.y) / 2.0);
 
 			break;
 
@@ -786,7 +853,7 @@ function calculateDiagonalAreaForPattern(pattern, left, right, offset, result) {
 			calculateDiagonalArea(pattern, p1.set(1.0, 0.0), p2.set(0.0 + d, 0.0 + d), left, offset, a1);
 			calculateDiagonalArea(pattern, p1.set(1.0, 0.0), p2.set(1.0 + d, 0.0 + d), left, offset, a2);
 
-			result.addVectors(a1, a2).divideScalar(2.0);
+			result.set((a1.x + a2.x) / 2.0, (a1.y + a2.y) / 2.0);
 
 			break;
 
@@ -804,7 +871,7 @@ function calculateDiagonalAreaForPattern(pattern, left, right, offset, result) {
 			calculateDiagonalArea(pattern, p1.set(0.0, 0.0), p2.set(1.0 + d, 0.0 + d), left, offset, a1);
 			calculateDiagonalArea(pattern, p1.set(1.0, 0.0), p2.set(1.0 + d, 0.0 + d), left, offset, a2);
 
-			result.addVectors(a1, a2).divideScalar(2.0);
+			result.set((a1.x + a2.x) / 2.0, (a1.y + a2.y) / 2.0);
 
 			break;
 
@@ -838,7 +905,7 @@ function calculateDiagonalAreaForPattern(pattern, left, right, offset, result) {
 			calculateDiagonalArea(pattern, p1.set(1.0, 1.0), p2.set(0.0 + d, 0.0 + d), left, offset, a1);
 			calculateDiagonalArea(pattern, p1.set(1.0, 1.0), p2.set(1.0 + d, 0.0 + d), left, offset, a2);
 
-			result.addVectors(a1, a2).divideScalar(2.0);
+			result.set((a1.x + a2.x) / 2.0, (a1.y + a2.y) / 2.0);
 
 			break;
 
@@ -857,7 +924,7 @@ function calculateDiagonalAreaForPattern(pattern, left, right, offset, result) {
 			calculateDiagonalArea(pattern, p1.set(1.0, 1.0), p2.set(0.0 + d, 0.0 + d), left, offset, a1);
 			calculateDiagonalArea(pattern, p1.set(1.0, 0.0), p2.set(1.0 + d, 0.0 + d), left, offset, a2);
 
-			result.addVectors(a1, a2).divideScalar(2.0);
+			result.set((a1.x + a2.x) / 2.0, (a1.y + a2.y) / 2.0);
 
 			break;
 
@@ -890,7 +957,7 @@ function calculateDiagonalAreaForPattern(pattern, left, right, offset, result) {
 			calculateDiagonalArea(pattern, p1.set(1.0, 1.0), p2.set(1.0 + d, 0.0 + d), left, offset, a1);
 			calculateDiagonalArea(pattern, p1.set(1.0, 0.0), p2.set(1.0 + d, 0.0 + d), left, offset, a2);
 
-			result.addVectors(a1, a2).divideScalar(2.0);
+			result.set((a1.x + a2.x) / 2.0, (a1.y + a2.y) / 2.0);
 
 			break;
 
@@ -909,7 +976,7 @@ function calculateDiagonalAreaForPattern(pattern, left, right, offset, result) {
 			calculateDiagonalArea(pattern, p1.set(0.0, 0.0), p2.set(1.0 + d, 1.0 + d), left, offset, a1);
 			calculateDiagonalArea(pattern, p1.set(1.0, 0.0), p2.set(1.0 + d, 1.0 + d), left, offset, a2);
 
-			result.addVectors(a1, a2).divideScalar(2.0);
+			result.set((a1.x + a2.x) / 2.0, (a1.y + a2.y) / 2.0);
 
 			break;
 
@@ -945,7 +1012,7 @@ function calculateDiagonalAreaForPattern(pattern, left, right, offset, result) {
 			calculateDiagonalArea(pattern, p1.set(0.0, 0.0), p2.set(1.0 + d, 1.0 + d), left, offset, a1);
 			calculateDiagonalArea(pattern, p1.set(1.0, 0.0), p2.set(1.0 + d, 0.0 + d), left, offset, a2);
 
-			result.addVectors(a1, a2).divideScalar(2.0);
+			result.set((a1.x + a2.x) / 2.0, (a1.y + a2.y) / 2.0);
 
 			break;
 
@@ -965,7 +1032,7 @@ function calculateDiagonalAreaForPattern(pattern, left, right, offset, result) {
 			calculateDiagonalArea(pattern, p1.set(1.0, 0.0), p2.set(1.0 + d, 1.0 + d), left, offset, a1);
 			calculateDiagonalArea(pattern, p1.set(1.0, 0.0), p2.set(1.0 + d, 0.0 + d), left, offset, a2);
 
-			result.addVectors(a1, a2).divideScalar(2.0);
+			result.set((a1.x + a2.x) / 2.0, (a1.y + a2.y) / 2.0);
 
 			break;
 
@@ -1000,7 +1067,7 @@ function calculateDiagonalAreaForPattern(pattern, left, right, offset, result) {
 			calculateDiagonalArea(pattern, p1.set(1.0, 1.0), p2.set(1.0 + d, 1.0 + d), left, offset, a1);
 			calculateDiagonalArea(pattern, p1.set(1.0, 0.0), p2.set(1.0 + d, 1.0 + d), left, offset, a2);
 
-			result.addVectors(a1, a2).divideScalar(2.0);
+			result.set((a1.x + a2.x) / 2.0, (a1.y + a2.y) / 2.0);
 
 			break;
 
@@ -1018,7 +1085,7 @@ function calculateDiagonalAreaForPattern(pattern, left, right, offset, result) {
 			calculateDiagonalArea(pattern, p1.set(1.0, 1.0), p2.set(1.0 + d, 1.0 + d), left, offset, a1);
 			calculateDiagonalArea(pattern, p1.set(1.0, 1.0), p2.set(1.0 + d, 0.0 + d), left, offset, a2);
 
-			result.addVectors(a1, a2).divideScalar(2.0);
+			result.set((a1.x + a2.x) / 2.0, (a1.y + a2.y) / 2.0);
 
 			break;
 
@@ -1038,7 +1105,7 @@ function calculateDiagonalAreaForPattern(pattern, left, right, offset, result) {
 			calculateDiagonalArea(pattern, p1.set(1.0, 1.0), p2.set(1.0 + d, 1.0 + d), left, offset, a1);
 			calculateDiagonalArea(pattern, p1.set(1.0, 0.0), p2.set(1.0 + d, 0.0 + d), left, offset, a2);
 
-			result.addVectors(a1, a2).divideScalar(2.0);
+			result.set((a1.x + a2.x) / 2.0, (a1.y + a2.y) / 2.0);
 
 			break;
 
@@ -1143,10 +1210,10 @@ function assemble(base, patterns, edges, size, orthogonal, target) {
 
 			for(x = 0; x < size; ++x) {
 
-				p.fromArray(edge).multiplyScalar(size);
-				p.add(base);
-				p.x += x;
-				p.y += y;
+				p.set(
+					edge[0] * size + base.x + x,
+					edge[1] * size + base.y + y
+				);
 
 				c = (p.y * dstWidth + p.x) * 2;
 

--- a/src/images/smaa/utils/SMAAImageLoader.js
+++ b/src/images/smaa/utils/SMAAImageLoader.js
@@ -16,28 +16,11 @@ function generate() {
 
 	return new Promise((resolve, reject) => {
 
-		//const loadingManager = new LoadingManager();
-		//loadingManager.onLoad = () => resolve(urls);
-
 		worker.addEventListener("error", (event) => reject(event.error));
 		worker.addEventListener("message", (event) => {
 
 			const searchImageData = RawImageData.from(event.data.searchImageData);
 			const areaImageData = RawImageData.from(event.data.areaImageData);
-
-			/*searchImageData.toCanvas().toBlob((blob) => {
-
-				urls[0] = URL.createObjectURL(blob);
-				loadingManager.itemEnd("smaa-search");
-
-			});
-
-			areaImageData.toCanvas().toBlob((blob) => {
-
-				urls[1] = URL.createObjectURL(blob);
-				loadingManager.itemEnd("smaa-area");
-
-			});*/
 
 			const urls = [
 				searchImageData.toCanvas().toDataURL(),
@@ -55,9 +38,6 @@ function generate() {
 			resolve(urls);
 
 		});
-
-		//loadingManager.itemStart("smaa-search");
-		//loadingManager.itemStart("smaa-area");
 
 		worker.postMessage(null);
 
@@ -135,7 +115,6 @@ export class SMAAImageLoader {
 
 				result.search.addEventListener("load", () => {
 
-					//URL.revokeObjectURL(urls[0]);
 					primaryManager.itemEnd("smaa-search");
 					secondaryManager.itemEnd("smaa-search");
 
@@ -143,7 +122,6 @@ export class SMAAImageLoader {
 
 				result.area.addEventListener("load", () => {
 
-					//URL.revokeObjectURL(urls[1]);
 					primaryManager.itemEnd("smaa-area");
 					secondaryManager.itemEnd("smaa-area");
 

--- a/src/images/smaa/utils/SMAAImageLoader.js
+++ b/src/images/smaa/utils/SMAAImageLoader.js
@@ -89,7 +89,7 @@ export class SMAAImageLoader {
 	 *
 	 * @param {Function} [onLoad] - A function to call when the loading process is done.
 	 * @param {Function} [onError] - A function to call when an error occurs.
-	 * @return {Promise} A promise that returns the search image and area image.
+	 * @return {Promise} A promise that returns the search image and area image as a tupel.
 	 */
 
 	load(onLoad = () => {}, onError = () => {}) {
@@ -104,18 +104,6 @@ export class SMAAImageLoader {
 
 		return new Promise((resolve, reject) => {
 
-			const result = {
-				search: new Image(),
-				area: new Image()
-			};
-
-			internalManager.onLoad = () => {
-
-				onLoad(result);
-				resolve(result);
-
-			};
-
 			const cachedURLs = (!this.disableCache && window.localStorage !== undefined) ? [
 				localStorage.getItem("smaa-search"),
 				localStorage.getItem("smaa-area")
@@ -126,22 +114,31 @@ export class SMAAImageLoader {
 
 			promise.then((urls) => {
 
-				result.search.addEventListener("load", () => {
+				const result = [new Image(), new Image()];
+
+				internalManager.onLoad = () => {
+
+					onLoad(result);
+					resolve(result);
+
+				};
+
+				result[0].addEventListener("load", () => {
 
 					externalManager.itemEnd("smaa-search");
 					internalManager.itemEnd("smaa-search");
 
 				});
 
-				result.area.addEventListener("load", () => {
+				result[1].addEventListener("load", () => {
 
 					externalManager.itemEnd("smaa-area");
 					internalManager.itemEnd("smaa-area");
 
 				});
 
-				result.search.src = urls[0];
-				result.area.src = urls[1];
+				result[0].src = urls[0];
+				result[1].src = urls[1];
 
 			}).catch((error) => {
 

--- a/src/images/smaa/utils/SMAAImageLoader.js
+++ b/src/images/smaa/utils/SMAAImageLoader.js
@@ -6,10 +6,11 @@ import workerProgram from "./worker.tmp";
  * Generates the SMAA data images.
  *
  * @private
+ * @param {Boolean} [useCache=true] - Determines whether the generated image data should be cached.
  * @return {Promise} A promise that returns the search image and area image blobs.
  */
 
-function generate() {
+function generate(useCache = true) {
 
 	const workerURL = URL.createObjectURL(new Blob([workerProgram], { type: "text/javascript" }));
 	const worker = new Worker(workerURL);
@@ -27,7 +28,7 @@ function generate() {
 				areaImageData.toCanvas().toDataURL()
 			];
 
-			if(window.localStorage !== undefined) {
+			if(useCache && window.localStorage !== undefined) {
 
 				localStorage.setItem("smaa-search", urls[0]);
 				localStorage.setItem("smaa-area", urls[1]);
@@ -49,7 +50,8 @@ function generate() {
  * An SMAA image loader.
  *
  * This loader uses a worker thread to generate the search and area images. The
- * Generated data URLs will be cached using localStorage, if available.
+ * Generated data URLs will be cached using localStorage, if available. To
+ * disable caching, use {@link SMAAImageLoader.useCache}.
  */
 
 export class SMAAImageLoader {
@@ -69,6 +71,14 @@ export class SMAAImageLoader {
 		 */
 
 		this.loadingManager = loadingManager;
+
+		/**
+		 * Indicates whether the generated image data should be cached.
+		 *
+		 * @type {Boolean}
+		 */
+
+		this.useCache = true;
 
 	}
 
@@ -104,13 +114,13 @@ export class SMAAImageLoader {
 
 			};
 
-			const cachedURLs = (window.localStorage !== undefined) ? [
+			const cachedURLs = (this.useCache && window.localStorage !== undefined) ? [
 				localStorage.getItem("smaa-search"),
 				localStorage.getItem("smaa-area")
 			] : [null, null];
 
 			const promise = (cachedURLs[0] !== null && cachedURLs[1] !== null) ?
-				Promise.resolve(cachedURLs) : generate();
+				Promise.resolve(cachedURLs) : generate(this.useCache);
 
 			promise.then((urls) => {
 

--- a/src/images/smaa/utils/SMAAImageLoader.js
+++ b/src/images/smaa/utils/SMAAImageLoader.js
@@ -48,7 +48,8 @@ function generate() {
 /**
  * An SMAA image loader.
  *
- * This loader uses a worker thread to generate the search and area images.
+ * This loader uses a worker thread to generate the search and area images. The
+ * Generated data URLs will be cached using localStorage, if available.
  */
 
 export class SMAAImageLoader {

--- a/src/images/smaa/utils/SMAAImageLoader.js
+++ b/src/images/smaa/utils/SMAAImageLoader.js
@@ -1,0 +1,169 @@
+import { LoadingManager } from "three";
+import { RawImageData } from "../../RawImageData.js";
+import workerProgram from "./worker.tmp";
+
+/**
+ * Generates the SMAA data images.
+ *
+ * @private
+ * @return {Promise} A promise that returns the search image and area image blobs.
+ */
+
+function generate() {
+
+	const workerURL = URL.createObjectURL(new Blob([workerProgram], { type: "text/javascript" }));
+	const worker = new Worker(workerURL);
+
+	return new Promise((resolve, reject) => {
+
+		//const loadingManager = new LoadingManager();
+		//loadingManager.onLoad = () => resolve(urls);
+
+		worker.addEventListener("error", (event) => reject(event.error));
+		worker.addEventListener("message", (event) => {
+
+			const searchImageData = RawImageData.from(event.data.searchImageData);
+			const areaImageData = RawImageData.from(event.data.areaImageData);
+
+			/*searchImageData.toCanvas().toBlob((blob) => {
+
+				urls[0] = URL.createObjectURL(blob);
+				loadingManager.itemEnd("smaa-search");
+
+			});
+
+			areaImageData.toCanvas().toBlob((blob) => {
+
+				urls[1] = URL.createObjectURL(blob);
+				loadingManager.itemEnd("smaa-area");
+
+			});*/
+
+			const urls = [
+				searchImageData.toCanvas().toDataURL(),
+				areaImageData.toCanvas().toDataURL()
+			];
+
+			if(window.localStorage !== undefined) {
+
+				localStorage.setItem("smaa-search", urls[0]);
+				localStorage.setItem("smaa-area", urls[1]);
+
+			}
+
+			URL.revokeObjectURL(workerURL);
+			resolve(urls);
+
+		});
+
+		//loadingManager.itemStart("smaa-search");
+		//loadingManager.itemStart("smaa-area");
+
+		worker.postMessage(null);
+
+	});
+
+}
+
+/**
+ * An SMAA image loader.
+ *
+ * This loader uses a worker thread to generate the search and area images.
+ */
+
+export class SMAAImageLoader {
+
+	/**
+	 * Constructs a new SMAA image loader.
+	 *
+	 * @param {LoadingManager} [loadingManager] - A loading manager.
+	 */
+
+	constructor(loadingManager = new LoadingManager()) {
+
+		/**
+		 * A loading manager.
+		 *
+		 * @type {LoadingManager}
+		 */
+
+		this.loadingManager = loadingManager;
+
+	}
+
+	/**
+	 * Loads the SMAA data images.
+	 *
+	 * @param {Function} [onLoad] - A function to call when the loading process is done.
+	 * @param {Function} [onError] - A function to call when an error occurs.
+	 * @return {Promise} A promise that returns the search image and area image as a tupel.
+	 */
+
+	load(onLoad = () => {}, onError = () => {}) {
+
+		const primaryManager = this.loadingManager;
+		const secondaryManager = new LoadingManager();
+
+		primaryManager.itemStart("smaa-search");
+		primaryManager.itemStart("smaa-area");
+		secondaryManager.itemStart("smaa-search");
+		secondaryManager.itemStart("smaa-area");
+
+		return new Promise((resolve, reject) => {
+
+			const result = {
+				search: new Image(),
+				area: new Image()
+			};
+
+			secondaryManager.onLoad = () => {
+
+				onLoad(result);
+				resolve(result);
+
+			};
+
+			const cachedURLs = (window.localStorage !== undefined) ? [
+				localStorage.getItem("smaa-search"),
+				localStorage.getItem("smaa-area")
+			] : [null, null];
+
+			const promise = (cachedURLs[0] !== null && cachedURLs[1] !== null) ?
+				Promise.resolve(cachedURLs) : generate();
+
+			promise.then((urls) => {
+
+				result.search.addEventListener("load", () => {
+
+					//URL.revokeObjectURL(urls[0]);
+					primaryManager.itemEnd("smaa-search");
+					secondaryManager.itemEnd("smaa-search");
+
+				});
+
+				result.area.addEventListener("load", () => {
+
+					//URL.revokeObjectURL(urls[1]);
+					primaryManager.itemEnd("smaa-area");
+					secondaryManager.itemEnd("smaa-area");
+
+				});
+
+				result.search.src = urls[0];
+				result.area.src = urls[1];
+
+			}).catch((error) => {
+
+				primaryManager.itemError("smaa-search");
+				primaryManager.itemError("smaa-area");
+
+				onError(error);
+				reject(error);
+
+			});
+
+		});
+
+	}
+
+}

--- a/src/images/smaa/utils/SMAASearchImageData.js
+++ b/src/images/smaa/utils/SMAASearchImageData.js
@@ -156,12 +156,13 @@ export class SMAASearchImageData {
 
 		const width = 66;
 		const height = 33;
+		const halfWidth = width / 2;
 
 		const croppedWidth = 64;
 		const croppedHeight = 16;
 
 		const data = new Uint8ClampedArray(width * height);
-		const croppedData = new Uint8ClampedArray(croppedWidth * croppedHeight);
+		const croppedData = new Uint8ClampedArray(croppedWidth * croppedHeight * 4);
 
 		let x, y;
 		let s, t, i;
@@ -180,9 +181,11 @@ export class SMAASearchImageData {
 					e1 = edges.get(s);
 					e2 = edges.get(t);
 
+					i = y * width + x;
+
 					// Maximize the dynamic range to help the compression.
-					data[y * width + x] = (127 * deltaLeft(e1, e2));
-					data[y * width + x + (width / 2)] = (127 * deltaRight(e1, e2));
+					data[i] = (127 * deltaLeft(e1, e2));
+					data[i + halfWidth] = (127 * deltaRight(e1, e2));
 
 				}
 
@@ -193,15 +196,16 @@ export class SMAASearchImageData {
 		// Crop the result to powers-of-two to make it BC4-friendly.
 		for(i = 0, y = height - croppedHeight; y < height; ++y) {
 
-			for(x = 0; x < croppedWidth; ++x, ++i) {
+			for(x = 0; x < croppedWidth; ++x, i += 4) {
 
 				croppedData[i] = data[y * width + x];
+				croppedData[i + 3] = 255;
 
 			}
 
 		}
 
-		return new RawImageData(croppedWidth, croppedHeight, croppedData, 1);
+		return new RawImageData(croppedWidth, croppedHeight, croppedData);
 
 	}
 

--- a/src/images/smaa/utils/worker.js
+++ b/src/images/smaa/utils/worker.js
@@ -1,0 +1,21 @@
+import { SMAAAreaImageData } from "./SMAAAreaImageData.js";
+import { SMAASearchImageData } from "./SMAASearchImageData.js";
+
+/**
+ * Handles messages from the main thread.
+ *
+ * @private
+ * @param {Event} event - A message event.
+ */
+
+self.addEventListener("message", function onMessage(event) {
+
+	const areaImageData = SMAAAreaImageData.generate();
+	const searchImageData = SMAASearchImageData.generate();
+
+	postMessage({ areaImageData, searchImageData },
+		[areaImageData.data.buffer, searchImageData.data.buffer]);
+
+	close();
+
+});

--- a/src/index.js
+++ b/src/index.js
@@ -46,6 +46,7 @@ export {
 export {
 	RawImageData,
 	SMAAAreaImageData,
+	SMAAImageLoader,
 	SMAASearchImageData
 } from "./images";
 


### PR DESCRIPTION
This PR introduces the new `SMAAImageLoader` class which generates the [search image](https://github.com/vanruesc/postprocessing/blob/master/src/images/smaa/search.png) and [area image](https://github.com/vanruesc/postprocessing/blob/master/src/images/smaa/area.png) in a worker thread. The generated images will be cached using the [localStorage](https://developer.mozilla.org/en-US/docs/Web/API/Window/localStorage) API. Caching can be disabled via the `SMAAImageLoader.disableCache` flag.

The goal of this loader is to make the process of loading the SMAA images easier. The loader also renders the [pre-generated base64 data URLs](https://github.com/vanruesc/postprocessing/blob/master/src/effects/SMAAEffect.js#L285-L321) obsolete - these strings will be removed in the next major release to reduce the size of the library.

_This loader is currently an experimental feature; its API might change in patch or minor releases._

#### Usage Example

```js
import { LoadingManager } from "three";
import { SMAAEffect, SMAAImageLoader } from "postprocessing";

const assets = new Map();
const loadingManager = new LoadingManager();
const smaaImageLoader = new SMAAImageLoader(loadingManager);

loadingManager.onError = console.error;
loadingManager.onLoad = () => {

	const smaaEffect = new SMAAEffect(
		assets.get("smaa-search"),
		assets.get("smaa-area")
	);

};

smaaImageLoader.load(([search, area]) => {

	assets.set("smaa-search", search);
	assets.set("smaa-area", area);

});
```
