### PR TITLE
Introduce multisample flag for EffectComposer

### DIFF
--- a/src/core/EffectComposer.js
+++ b/src/core/EffectComposer.js
@@ -6,7 +6,8 @@ import {
 	RGBFormat,
 	UnsignedInt248Type,
 	Vector2,
-	WebGLRenderTarget
+	WebGLRenderTarget,
+	WebGLMultisampleRenderTarget
 } from "three";
 
 import { ClearMaskPass, MaskPass, ShaderPass } from "../passes";
@@ -34,10 +35,11 @@ export class EffectComposer {
 	 * @param {Object} [options] - The options.
 	 * @param {Boolean} [options.depthBuffer=true] - Whether the main render targets should have a depth buffer.
 	 * @param {Boolean} [options.stencilBuffer=false] - Whether the main render targets should have a stencil buffer.
+	 * @param {Boolean} [options.multisample=false] - Whether to enable WebGL2 Multisample Render Targets between the render passes.
 	 * @param {Boolean} [options.frameBufferType] - The type of the internal frame buffers. It's recommended to use HalfFloatType if possible.
 	 */
 
-	constructor(renderer = null, { depthBuffer = true, stencilBuffer = false, frameBufferType } = {}) {
+	constructor(renderer = null, { depthBuffer = true, stencilBuffer = false, multisample = false, frameBufferType } = {}) {
 
 		/**
 		 * The renderer.
@@ -72,7 +74,7 @@ export class EffectComposer {
 		if(this.renderer !== null) {
 
 			this.renderer.autoClear = false;
-			this.inputBuffer = this.createBuffer(depthBuffer, stencilBuffer, frameBufferType);
+			this.inputBuffer = this.createBuffer(depthBuffer, stencilBuffer, frameBufferType, multisample);
 			this.outputBuffer = this.inputBuffer.clone();
 
 		}
@@ -213,15 +215,17 @@ export class EffectComposer {
 	 * @param {Boolean} depthBuffer - Whether the render target should have a depth buffer.
 	 * @param {Boolean} stencilBuffer - Whether the render target should have a stencil buffer.
 	 * @param {Number} type - The frame buffer type.
+	 * @param {Boolean} multisample - Whether the render target should be multisampled.
 	 * @return {WebGLRenderTarget} A new render target that equals the renderer's canvas.
 	 */
 
-	createBuffer(depthBuffer, stencilBuffer, type) {
+	createBuffer(depthBuffer, stencilBuffer, type, multisample) {
 
 		const drawingBufferSize = this.renderer.getDrawingBufferSize(new Vector2());
 		const alpha = this.renderer.getContext().getContextAttributes().alpha;
 
-		const renderTarget = new WebGLRenderTarget(drawingBufferSize.width, drawingBufferSize.height, {
+		const RenderTargetType = multisample ? WebGLMultisampleRenderTarget : WebGLRenderTarget;
+		const renderTarget = new RenderTargetType(drawingBufferSize.width, drawingBufferSize.height, {
 			format: alpha ? RGBAFormat : RGBFormat,
 			minFilter: LinearFilter,
 			magFilter: LinearFilter,


### PR DESCRIPTION
This commit introduces support for the new WebGLMultisampleRenderTarget in three.js.
It can be used to render a geometry pass, resolve MSAA and apply effects afterwards.